### PR TITLE
refactor: use import maps for npm deps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,11 @@
 		]
 	},
 	"imports": {
-		"@std/assert": "jsr:@std/assert@^1.0.2"
+		"@std/assert": "jsr:@std/assert@^1.0.2",
+		"curve25519-js": "npm:curve25519-js@^0.0.4",
+		"node-bignumber": "npm:node-bignumber@^1.2.2",
+		"thrift": "npm:thrift@^0.20.0",
+		"tweetnacl": "npm:tweetnacl@^1.0.3"
 	},
 	"tasks": {
 		"format": "deno fmt & deno run -A npm:@biomejs/biome format --write ./packages/**/*.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -10,14 +10,18 @@
       "npm:crypto-js": "npm:crypto-js@4.2.0",
       "npm:curve25519-js": "npm:curve25519-js@0.0.4",
       "npm:curve25519-js@0.0.4": "npm:curve25519-js@0.0.4",
+      "npm:curve25519-js@^0.0.4": "npm:curve25519-js@0.0.4",
       "npm:elliptic": "npm:elliptic@6.5.7",
       "npm:elliptic@6.5.7": "npm:elliptic@6.5.7",
       "npm:node-bignumber": "npm:node-bignumber@1.2.2",
       "npm:node-bignumber@1.2.2": "npm:node-bignumber@1.2.2",
+      "npm:node-bignumber@^1.2.2": "npm:node-bignumber@1.2.2",
       "npm:prettier": "npm:prettier@3.3.3",
       "npm:thrift@0.20.0": "npm:thrift@0.20.0_ws@5.2.4",
+      "npm:thrift@^0.20.0": "npm:thrift@0.20.0_ws@5.2.4",
       "npm:tweetnacl": "npm:tweetnacl@1.0.3",
-      "npm:tweetnacl@1.0.3": "npm:tweetnacl@1.0.3"
+      "npm:tweetnacl@1.0.3": "npm:tweetnacl@1.0.3",
+      "npm:tweetnacl@^1.0.3": "npm:tweetnacl@1.0.3"
     },
     "jsr": {
       "@std/assert@1.0.2": {
@@ -200,7 +204,11 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@^1.0.2"
+      "jsr:@std/assert@^1.0.2",
+      "npm:curve25519-js@^0.0.4",
+      "npm:node-bignumber@^1.2.2",
+      "npm:thrift@^0.20.0",
+      "npm:tweetnacl@^1.0.3"
     ]
   }
 }

--- a/packages/client/clients/e2ee/index.ts
+++ b/packages/client/clients/e2ee/index.ts
@@ -1,5 +1,5 @@
 //import CryptoJS from "npm:crypto-js@4.2.0";
-import * as curve25519 from "npm:curve25519-js@0.0.4";
+import * as curve25519 from "curve25519-js";
 import * as crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 import { TalkClient } from "../internal/talk-client.ts";
@@ -11,7 +11,7 @@ import {
 	type Message,
 	MIDType,
 } from "../../libs/thrift/line_types.ts";
-import nacl from "npm:tweetnacl@1.0.3";
+import nacl from "tweetnacl";
 
 class E2EE extends TalkClient {
 	public async getE2EESelfKeyData(mid: string): Promise<LooseType> {

--- a/packages/client/libs/rsa/rsa-verify.ts
+++ b/packages/client/libs/rsa/rsa-verify.ts
@@ -1,4 +1,4 @@
-import { Key } from "npm:node-bignumber@1.2.2";
+import { Key } from "node-bignumber";
 import type { RSAKey } from "../thrift/line_types.ts";
 
 export function getRSACrypto(message: string, json: RSAKey) {

--- a/packages/client/libs/thrift/declares.ts
+++ b/packages/client/libs/thrift/declares.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { TBinaryProtocol, TCompactProtocol } from "npm:thrift@0.20.0";
+import { TBinaryProtocol, TCompactProtocol } from "thrift";
 import type { LooseType } from "../../entities/common.ts";
 
 TBinaryProtocol.genHeader = (name: string) => {

--- a/packages/client/libs/thrift/read.ts
+++ b/packages/client/libs/thrift/read.ts
@@ -1,4 +1,4 @@
-import * as thrift from "npm:thrift@0.20.0";
+import * as thrift from "thrift";
 import { Buffer } from "node:buffer";
 import type { LooseType } from "../../entities/common.ts";
 

--- a/packages/client/libs/thrift/write.ts
+++ b/packages/client/libs/thrift/write.ts
@@ -1,4 +1,4 @@
-import * as thrift from "npm:thrift@0.20.0";
+import * as thrift from "thrift";
 import { Buffer } from "node:buffer";
 import type { NestedArray, ProtocolKey, Protocols } from "./declares.ts";
 import type { LooseType } from "../../entities/common.ts";


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

Currently imports of the codes use `npm:package@version` syntax. But it may make version inconsistency. So I recommend to use import maps.
In JSR, import maps is supported.

## Checklist

- [x] Run tests (optional)
- [ ] Add jsdoc (optional)
- [ ] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.
