### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/message-event.md
+++ b/docs/docs/message-event.md
@@ -60,7 +60,7 @@ client.on("message", (message) => {
     const text = message.content;
 
     if (text === "!ping") {
-        client.reply("pong!");
+        message.reply("pong!");
     }
 });
 ```


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

https://linejs.evex.land/docs/message-event#chat is wrong.

\- `client.reply`
\+ `message.reply`

## Checklist

- [ ] Run tests (optional)
- [ ] Add jsdoc (optional)
- [ ] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.
