### PR TITLE
feat(event-emitter): add `promise` method

### DIFF
--- a/packages/client/libs/thrift/line_types.ts
+++ b/packages/client/libs/thrift/line_types.ts
@@ -313,8 +313,7 @@ export enum ErrorCode {
 	INTERNAL_ERROR = 20,
 	_NO_SUCH_IDENTITY_IDENFIER = "NO_SUCH_IDENTITY_IDENFIER",
 	NO_SUCH_IDENTITY_IDENFIER = 21,
-	_DEACTIVATED_ACCOUNT_BOUND_TO_THIS_IDENTITY =
-		"DEACTIVATED_ACCOUNT_BOUND_TO_THIS_IDENTITY",
+	_DEACTIVATED_ACCOUNT_BOUND_TO_THIS_IDENTITY = "DEACTIVATED_ACCOUNT_BOUND_TO_THIS_IDENTITY",
 	DEACTIVATED_ACCOUNT_BOUND_TO_THIS_IDENTITY = 22,
 	_ILLEGAL_IDENTITY_CREDENTIAL = "ILLEGAL_IDENTITY_CREDENTIAL",
 	ILLEGAL_IDENTITY_CREDENTIAL = 23,
@@ -392,16 +391,13 @@ export enum ErrorCode {
 	NO_CALLER_ID_LIMIT_EXCEEDED = 61,
 	_CALLER_ID_VERIFICATION_REQUIRED = "CALLER_ID_VERIFICATION_REQUIRED",
 	CALLER_ID_VERIFICATION_REQUIRED = 62,
-	_NO_CALLER_ID_LIMIT_EXCEEDED_AND_VERIFICATION_REQUIRED =
-		"NO_CALLER_ID_LIMIT_EXCEEDED_AND_VERIFICATION_REQUIRED",
+	_NO_CALLER_ID_LIMIT_EXCEEDED_AND_VERIFICATION_REQUIRED = "NO_CALLER_ID_LIMIT_EXCEEDED_AND_VERIFICATION_REQUIRED",
 	NO_CALLER_ID_LIMIT_EXCEEDED_AND_VERIFICATION_REQUIRED = 63,
 	_MESSAGE_NOT_FOUND = "MESSAGE_NOT_FOUND",
 	MESSAGE_NOT_FOUND = 64,
-	_INVALID_ACCOUNT_MIGRATION_PINCODE_FORMAT =
-		"INVALID_ACCOUNT_MIGRATION_PINCODE_FORMAT",
+	_INVALID_ACCOUNT_MIGRATION_PINCODE_FORMAT = "INVALID_ACCOUNT_MIGRATION_PINCODE_FORMAT",
 	INVALID_ACCOUNT_MIGRATION_PINCODE_FORMAT = 65,
-	_ACCOUNT_MIGRATION_PINCODE_NOT_MATCHED =
-		"ACCOUNT_MIGRATION_PINCODE_NOT_MATCHED",
+	_ACCOUNT_MIGRATION_PINCODE_NOT_MATCHED = "ACCOUNT_MIGRATION_PINCODE_NOT_MATCHED",
 	ACCOUNT_MIGRATION_PINCODE_NOT_MATCHED = 66,
 	_ACCOUNT_MIGRATION_PINCODE_BLOCKED = "ACCOUNT_MIGRATION_PINCODE_BLOCKED",
 	ACCOUNT_MIGRATION_PINCODE_BLOCKED = 67,
@@ -415,11 +411,9 @@ export enum ErrorCode {
 	PAID_CALL_REDEEM_FAILED = 72,
 	_PREVENTED_JOIN_BY_TICKET = "PREVENTED_JOIN_BY_TICKET",
 	PREVENTED_JOIN_BY_TICKET = 73,
-	_SEND_MESSAGE_NOT_PERMITTED_FROM_LINE_AT =
-		"SEND_MESSAGE_NOT_PERMITTED_FROM_LINE_AT",
+	_SEND_MESSAGE_NOT_PERMITTED_FROM_LINE_AT = "SEND_MESSAGE_NOT_PERMITTED_FROM_LINE_AT",
 	SEND_MESSAGE_NOT_PERMITTED_FROM_LINE_AT = 75,
-	_SEND_MESSAGE_NOT_PERMITTED_WHILE_AUTO_REPLY =
-		"SEND_MESSAGE_NOT_PERMITTED_WHILE_AUTO_REPLY",
+	_SEND_MESSAGE_NOT_PERMITTED_WHILE_AUTO_REPLY = "SEND_MESSAGE_NOT_PERMITTED_WHILE_AUTO_REPLY",
 	SEND_MESSAGE_NOT_PERMITTED_WHILE_AUTO_REPLY = 76,
 	_SECURITY_CENTER_NOT_VERIFIED = "SECURITY_CENTER_NOT_VERIFIED",
 	SECURITY_CENTER_NOT_VERIFIED = 77,
@@ -687,8 +681,7 @@ export enum PwlessCredentialErrorCode {
 	NOT_SUPPORTED = 101,
 	_FORBIDDEN = "FORBIDDEN",
 	FORBIDDEN = 102,
-	_FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR =
-		"FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR",
+	_FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR = "FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR",
 	FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR = 201,
 }
 
@@ -747,8 +740,7 @@ export enum SecondaryPwlessLoginErrorCode {
 	FORBIDDEN = 103,
 	_FIDO_UNKNOWN_CREDENTIAL_ID = "FIDO_UNKNOWN_CREDENTIAL_ID",
 	FIDO_UNKNOWN_CREDENTIAL_ID = 200,
-	_FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR =
-		"FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR",
+	_FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR = "FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR",
 	FIDO_RETRY_WITH_ANOTHER_AUTHENTICATOR = 201,
 	_FIDO_UNACCEPTABLE_CONTENT = "FIDO_UNACCEPTABLE_CONTENT",
 	FIDO_UNACCEPTABLE_CONTENT = 202,
@@ -1710,11 +1702,9 @@ export enum VerificationMethod {
 }
 
 export enum ContactSetting {
-	_CONTACT_SETTING_NOTIFICATION_DISABLE =
-		"CONTACT_SETTING_NOTIFICATION_DISABLE",
+	_CONTACT_SETTING_NOTIFICATION_DISABLE = "CONTACT_SETTING_NOTIFICATION_DISABLE",
 	CONTACT_SETTING_NOTIFICATION_DISABLE = 1,
-	_CONTACT_SETTING_DISPLAY_NAME_OVERRIDE =
-		"CONTACT_SETTING_DISPLAY_NAME_OVERRIDE",
+	_CONTACT_SETTING_DISPLAY_NAME_OVERRIDE = "CONTACT_SETTING_DISPLAY_NAME_OVERRIDE",
 	CONTACT_SETTING_DISPLAY_NAME_OVERRIDE = 2,
 	_CONTACT_SETTING_CONTACT_HIDE = "CONTACT_SETTING_CONTACT_HIDE",
 	CONTACT_SETTING_CONTACT_HIDE = 4,
@@ -2109,8 +2099,7 @@ export enum SquareEventType {
 	NOTIFIED_DESTROY_MESSAGE = 5,
 	_NOTIFIED_MARK_AS_READ = "NOTIFIED_MARK_AS_READ",
 	NOTIFIED_MARK_AS_READ = 6,
-	_NOTIFIED_UPDATE_SQUARE_MEMBER_PROFILE =
-		"NOTIFIED_UPDATE_SQUARE_MEMBER_PROFILE",
+	_NOTIFIED_UPDATE_SQUARE_MEMBER_PROFILE = "NOTIFIED_UPDATE_SQUARE_MEMBER_PROFILE",
 	NOTIFIED_UPDATE_SQUARE_MEMBER_PROFILE = 7,
 	_NOTIFIED_KICKOUT_FROM_SQUARE = "NOTIFIED_KICKOUT_FROM_SQUARE",
 	NOTIFIED_KICKOUT_FROM_SQUARE = 19,
@@ -2118,17 +2107,13 @@ export enum SquareEventType {
 	NOTIFIED_SHUTDOWN_SQUARE = 18,
 	_NOTIFIED_DELETE_SQUARE_CHAT = "NOTIFIED_DELETE_SQUARE_CHAT",
 	NOTIFIED_DELETE_SQUARE_CHAT = 20,
-	_NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_NAME =
-		"NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_NAME",
+	_NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_NAME = "NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_NAME",
 	NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_NAME = 30,
-	_NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_IMAGE =
-		"NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_IMAGE",
+	_NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_IMAGE = "NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_IMAGE",
 	NOTIFIED_UPDATE_SQUARE_CHAT_PROFILE_IMAGE = 31,
-	_NOTIFIED_UPDATE_SQUARE_CHAT_MAX_MEMBER_COUNT =
-		"NOTIFIED_UPDATE_SQUARE_CHAT_MAX_MEMBER_COUNT",
+	_NOTIFIED_UPDATE_SQUARE_CHAT_MAX_MEMBER_COUNT = "NOTIFIED_UPDATE_SQUARE_CHAT_MAX_MEMBER_COUNT",
 	NOTIFIED_UPDATE_SQUARE_CHAT_MAX_MEMBER_COUNT = 38,
-	_NOTIFIED_UPDATE_SQUARE_CHAT_ANNOUNCEMENT =
-		"NOTIFIED_UPDATE_SQUARE_CHAT_ANNOUNCEMENT",
+	_NOTIFIED_UPDATE_SQUARE_CHAT_ANNOUNCEMENT = "NOTIFIED_UPDATE_SQUARE_CHAT_ANNOUNCEMENT",
 	NOTIFIED_UPDATE_SQUARE_CHAT_ANNOUNCEMENT = 37,
 	_NOTIFIED_ADD_BOT = "NOTIFIED_ADD_BOT",
 	NOTIFIED_ADD_BOT = 33,
@@ -2160,13 +2145,11 @@ export enum SquareEventType {
 	NOTIFIED_CREATE_SQUARE_MEMBER = 15,
 	_NOTIFIED_CREATE_SQUARE_CHAT_MEMBER = "NOTIFIED_CREATE_SQUARE_CHAT_MEMBER",
 	NOTIFIED_CREATE_SQUARE_CHAT_MEMBER = 16,
-	_NOTIFIED_UPDATE_SQUARE_MEMBER_RELATION =
-		"NOTIFIED_UPDATE_SQUARE_MEMBER_RELATION",
+	_NOTIFIED_UPDATE_SQUARE_MEMBER_RELATION = "NOTIFIED_UPDATE_SQUARE_MEMBER_RELATION",
 	NOTIFIED_UPDATE_SQUARE_MEMBER_RELATION = 17,
 	_NOTIFIED_UPDATE_SQUARE_FEATURE_SET = "NOTIFIED_UPDATE_SQUARE_FEATURE_SET",
 	NOTIFIED_UPDATE_SQUARE_FEATURE_SET = 32,
-	_NOTIFIED_UPDATE_SQUARE_CHAT_FEATURE_SET =
-		"NOTIFIED_UPDATE_SQUARE_CHAT_FEATURE_SET",
+	_NOTIFIED_UPDATE_SQUARE_CHAT_FEATURE_SET = "NOTIFIED_UPDATE_SQUARE_CHAT_FEATURE_SET",
 	NOTIFIED_UPDATE_SQUARE_CHAT_FEATURE_SET = 50,
 	_NOTIFIED_UPDATE_SQUARE_NOTE_STATUS = "NOTIFIED_UPDATE_SQUARE_NOTE_STATUS",
 	NOTIFIED_UPDATE_SQUARE_NOTE_STATUS = 36,
@@ -2361,16 +2344,13 @@ export enum SquareChatThreadeMembershipState {
 export enum LiveTalkEventType {
 	_NOTIFIED_UPDATE_LIVE_TALK_TITLE = "NOTIFIED_UPDATE_LIVE_TALK_TITLE",
 	NOTIFIED_UPDATE_LIVE_TALK_TITLE = 1,
-	_NOTIFIED_UPDATE_LIVE_TALK_SPEAKER_SETTING =
-		"NOTIFIED_UPDATE_LIVE_TALK_SPEAKER_SETTING",
+	_NOTIFIED_UPDATE_LIVE_TALK_SPEAKER_SETTING = "NOTIFIED_UPDATE_LIVE_TALK_SPEAKER_SETTING",
 	NOTIFIED_UPDATE_LIVE_TALK_SPEAKER_SETTING = 2,
-	_NOTIFIED_UPDATE_LIVE_TALK_ANNOUNCEMENT =
-		"NOTIFIED_UPDATE_LIVE_TALK_ANNOUNCEMENT",
+	_NOTIFIED_UPDATE_LIVE_TALK_ANNOUNCEMENT = "NOTIFIED_UPDATE_LIVE_TALK_ANNOUNCEMENT",
 	NOTIFIED_UPDATE_LIVE_TALK_ANNOUNCEMENT = 3,
 	_NOTIFIED_UPDATE_SQUARE_MEMBER_ROLE = "NOTIFIED_UPDATE_SQUARE_MEMBER_ROLE",
 	NOTIFIED_UPDATE_SQUARE_MEMBER_ROLE = 4,
-	_NOTIFIED_UPDATE_LIVE_TALK_ALLOW_REQUEST_TO_SPEAK =
-		"NOTIFIED_UPDATE_LIVE_TALK_ALLOW_REQUEST_TO_SPEAK",
+	_NOTIFIED_UPDATE_LIVE_TALK_ALLOW_REQUEST_TO_SPEAK = "NOTIFIED_UPDATE_LIVE_TALK_ALLOW_REQUEST_TO_SPEAK",
 	NOTIFIED_UPDATE_LIVE_TALK_ALLOW_REQUEST_TO_SPEAK = 5,
 }
 
@@ -5429,8 +5409,7 @@ export declare class SquareEventPayload {
 	notifiedLeaveSquareChat: SquareEventNotifiedLeaveSquareChat;
 	notifiedDestroyMessage: SquareEventNotifiedDestroyMessage;
 	notifiedMarkAsRead: SquareEventNotifiedMarkAsRead;
-	notifiedUpdateSquareMemberProfile:
-		SquareEventNotifiedUpdateSquareMemberProfile;
+	notifiedUpdateSquareMemberProfile: SquareEventNotifiedUpdateSquareMemberProfile;
 	notifiedUpdateSquare: SquareEventNotifiedUpdateSquare;
 	notifiedUpdateSquareMember: SquareEventNotifiedUpdateSquareMember;
 	notifiedUpdateSquareChat: SquareEventNotifiedUpdateSquareChat;
@@ -5440,8 +5419,7 @@ export declare class SquareEventPayload {
 	notifiedUpdateSquareChatStatus: SquareEventNotifiedUpdateSquareChatStatus;
 	notifiedCreateSquareMember: SquareEventNotifiedCreateSquareMember;
 	notifiedCreateSquareChatMember: SquareEventNotifiedCreateSquareChatMember;
-	notifiedUpdateSquareMemberRelation:
-		SquareEventNotifiedUpdateSquareMemberRelation;
+	notifiedUpdateSquareMemberRelation: SquareEventNotifiedUpdateSquareMemberRelation;
 	notifiedShutdownSquare: SquareEventNotifiedShutdownSquare;
 	notifiedKickoutFromSquare: SquareEventNotifiedKickoutFromSquare;
 	notifiedDeleteSquareChat: SquareEventNotifiedDeleteSquareChat;
@@ -5454,18 +5432,14 @@ export declare class SquareEventPayload {
 	notificationSquareDelete: SquareEventNotificationSquareDelete;
 	notificationSquareChatDelete: SquareEventNotificationSquareChatDelete;
 	notificationMessage: SquareEventNotificationMessage;
-	notifiedUpdateSquareChatProfileName:
-		SquareEventNotifiedUpdateSquareChatProfileName;
-	notifiedUpdateSquareChatProfileImage:
-		SquareEventNotifiedUpdateSquareChatProfileImage;
+	notifiedUpdateSquareChatProfileName: SquareEventNotifiedUpdateSquareChatProfileName;
+	notifiedUpdateSquareChatProfileImage: SquareEventNotifiedUpdateSquareChatProfileImage;
 	notifiedUpdateSquareFeatureSet: SquareEventNotifiedUpdateSquareFeatureSet;
 	notifiedAddBot: SquareEventNotifiedAddBot;
 	notifiedRemoveBot: SquareEventNotifiedRemoveBot;
 	notifiedUpdateSquareNoteStatus: SquareEventNotifiedUpdateSquareNoteStatus;
-	notifiedUpdateSquareChatAnnouncement:
-		SquareEventNotifiedUpdateSquareChatAnnouncement;
-	notifiedUpdateSquareChatMaxMemberCount:
-		SquareEventNotifiedUpdateSquareChatMaxMemberCount;
+	notifiedUpdateSquareChatAnnouncement: SquareEventNotifiedUpdateSquareChatAnnouncement;
+	notifiedUpdateSquareChatMaxMemberCount: SquareEventNotifiedUpdateSquareChatMaxMemberCount;
 	notificationPostAnnouncement: SquareEventNotificationPostAnnouncement;
 	notificationPost: SquareEventNotificationPost;
 	mutateMessage: SquareEventMutateMessage;
@@ -5475,8 +5449,7 @@ export declare class SquareEventPayload {
 	notificationMessageReaction: SquareEventNotificationMessageReaction;
 	chatPopup: SquareEventChatPopup;
 	notifiedSystemMessage: SquareEventNotifiedSystemMessage;
-	notifiedUpdateSquareChatFeatureSet:
-		SquareEventNotifiedUpdateSquareChatFeatureSet;
+	notifiedUpdateSquareChatFeatureSet: SquareEventNotifiedUpdateSquareChatFeatureSet;
 
 	constructor(args?: {
 		receiveMessage: SquareEventReceiveMessage;
@@ -5486,8 +5459,7 @@ export declare class SquareEventPayload {
 		notifiedLeaveSquareChat: SquareEventNotifiedLeaveSquareChat;
 		notifiedDestroyMessage: SquareEventNotifiedDestroyMessage;
 		notifiedMarkAsRead: SquareEventNotifiedMarkAsRead;
-		notifiedUpdateSquareMemberProfile:
-			SquareEventNotifiedUpdateSquareMemberProfile;
+		notifiedUpdateSquareMemberProfile: SquareEventNotifiedUpdateSquareMemberProfile;
 		notifiedUpdateSquare: SquareEventNotifiedUpdateSquare;
 		notifiedUpdateSquareMember: SquareEventNotifiedUpdateSquareMember;
 		notifiedUpdateSquareChat: SquareEventNotifiedUpdateSquareChat;
@@ -5497,8 +5469,7 @@ export declare class SquareEventPayload {
 		notifiedUpdateSquareChatStatus: SquareEventNotifiedUpdateSquareChatStatus;
 		notifiedCreateSquareMember: SquareEventNotifiedCreateSquareMember;
 		notifiedCreateSquareChatMember: SquareEventNotifiedCreateSquareChatMember;
-		notifiedUpdateSquareMemberRelation:
-			SquareEventNotifiedUpdateSquareMemberRelation;
+		notifiedUpdateSquareMemberRelation: SquareEventNotifiedUpdateSquareMemberRelation;
 		notifiedShutdownSquare: SquareEventNotifiedShutdownSquare;
 		notifiedKickoutFromSquare: SquareEventNotifiedKickoutFromSquare;
 		notifiedDeleteSquareChat: SquareEventNotifiedDeleteSquareChat;
@@ -5511,18 +5482,14 @@ export declare class SquareEventPayload {
 		notificationSquareDelete: SquareEventNotificationSquareDelete;
 		notificationSquareChatDelete: SquareEventNotificationSquareChatDelete;
 		notificationMessage: SquareEventNotificationMessage;
-		notifiedUpdateSquareChatProfileName:
-			SquareEventNotifiedUpdateSquareChatProfileName;
-		notifiedUpdateSquareChatProfileImage:
-			SquareEventNotifiedUpdateSquareChatProfileImage;
+		notifiedUpdateSquareChatProfileName: SquareEventNotifiedUpdateSquareChatProfileName;
+		notifiedUpdateSquareChatProfileImage: SquareEventNotifiedUpdateSquareChatProfileImage;
 		notifiedUpdateSquareFeatureSet: SquareEventNotifiedUpdateSquareFeatureSet;
 		notifiedAddBot: SquareEventNotifiedAddBot;
 		notifiedRemoveBot: SquareEventNotifiedRemoveBot;
 		notifiedUpdateSquareNoteStatus: SquareEventNotifiedUpdateSquareNoteStatus;
-		notifiedUpdateSquareChatAnnouncement:
-			SquareEventNotifiedUpdateSquareChatAnnouncement;
-		notifiedUpdateSquareChatMaxMemberCount:
-			SquareEventNotifiedUpdateSquareChatMaxMemberCount;
+		notifiedUpdateSquareChatAnnouncement: SquareEventNotifiedUpdateSquareChatAnnouncement;
+		notifiedUpdateSquareChatMaxMemberCount: SquareEventNotifiedUpdateSquareChatMaxMemberCount;
 		notificationPostAnnouncement: SquareEventNotificationPostAnnouncement;
 		notificationPost: SquareEventNotificationPost;
 		mutateMessage: SquareEventMutateMessage;
@@ -5532,8 +5499,7 @@ export declare class SquareEventPayload {
 		notificationMessageReaction: SquareEventNotificationMessageReaction;
 		chatPopup: SquareEventChatPopup;
 		notifiedSystemMessage: SquareEventNotifiedSystemMessage;
-		notifiedUpdateSquareChatFeatureSet:
-			SquareEventNotifiedUpdateSquareChatFeatureSet;
+		notifiedUpdateSquareChatFeatureSet: SquareEventNotifiedUpdateSquareChatFeatureSet;
 	});
 }
 
@@ -5913,23 +5879,17 @@ export declare class LiveTalkEventNotifiedUpdateLiveTalkAllowRequestToSpeak {
 
 export declare class LiveTalkEventPayload {
 	notifiedUpdateLiveTalkTitle: LiveTalkEventNotifiedUpdateLiveTalkTitle;
-	notifiedUpdateLiveTalkSpeakerSetting:
-		LiveTalkEventNotifiedUpdateLiveTalkSpeakerSetting;
-	notifiedUpdateLiveTalkAnnouncement:
-		LiveTalkEventNotifiedUpdateLiveTalkAnnouncement;
+	notifiedUpdateLiveTalkSpeakerSetting: LiveTalkEventNotifiedUpdateLiveTalkSpeakerSetting;
+	notifiedUpdateLiveTalkAnnouncement: LiveTalkEventNotifiedUpdateLiveTalkAnnouncement;
 	notifiedUpdateSquareMemberRole: LiveTalkEventNotifiedUpdateSquareMemberRole;
-	notifiedUpdateLiveTalkAllowRequestToSpeak:
-		LiveTalkEventNotifiedUpdateLiveTalkAllowRequestToSpeak;
+	notifiedUpdateLiveTalkAllowRequestToSpeak: LiveTalkEventNotifiedUpdateLiveTalkAllowRequestToSpeak;
 
 	constructor(args?: {
 		notifiedUpdateLiveTalkTitle: LiveTalkEventNotifiedUpdateLiveTalkTitle;
-		notifiedUpdateLiveTalkSpeakerSetting:
-			LiveTalkEventNotifiedUpdateLiveTalkSpeakerSetting;
-		notifiedUpdateLiveTalkAnnouncement:
-			LiveTalkEventNotifiedUpdateLiveTalkAnnouncement;
+		notifiedUpdateLiveTalkSpeakerSetting: LiveTalkEventNotifiedUpdateLiveTalkSpeakerSetting;
+		notifiedUpdateLiveTalkAnnouncement: LiveTalkEventNotifiedUpdateLiveTalkAnnouncement;
 		notifiedUpdateSquareMemberRole: LiveTalkEventNotifiedUpdateSquareMemberRole;
-		notifiedUpdateLiveTalkAllowRequestToSpeak:
-			LiveTalkEventNotifiedUpdateLiveTalkAllowRequestToSpeak;
+		notifiedUpdateLiveTalkAllowRequestToSpeak: LiveTalkEventNotifiedUpdateLiveTalkAllowRequestToSpeak;
 	});
 }
 

--- a/packages/client/libs/typed-event-emitter/index.test.ts
+++ b/packages/client/libs/typed-event-emitter/index.test.ts
@@ -8,7 +8,7 @@ Deno.test("promise() should be vaild", async () => {
 	class Client extends TypedEventEmitter<Events> {}
 	const client = new Client();
 
-	const promise = client.promise("example");
+	const promise = client.waitFor("example");
 
 	client.emit("example", 123456);
 

--- a/packages/client/libs/typed-event-emitter/index.test.ts
+++ b/packages/client/libs/typed-event-emitter/index.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "@std/assert";
+import { TypedEventEmitter } from "./index.ts";
+
+Deno.test("promise() should be vaild", async () => {
+	type Events = {
+		example: (v: number) => void;
+	};
+	class Client extends TypedEventEmitter<Events> {}
+	const client = new Client();
+
+	const promise = client.promise("example");
+
+	client.emit("example", 123456);
+
+	const [v] = await promise;
+
+	assertEquals(v, 123456);
+});

--- a/packages/client/libs/typed-event-emitter/index.ts
+++ b/packages/client/libs/typed-event-emitter/index.ts
@@ -43,7 +43,8 @@ export class TypedEventEmitter<
 	}
 
 	/**
-	 * Creating a promise, you can use it for once event.
+	 * This creates a promise that you can use for a single event.
+	 * @param event A event name
 	 */
 	public promise<E2 extends E, P extends unknown[] = Parameters<T[E2]>>(
 		event: E2,

--- a/packages/client/libs/typed-event-emitter/index.ts
+++ b/packages/client/libs/typed-event-emitter/index.ts
@@ -46,7 +46,7 @@ export class TypedEventEmitter<
 	 * This creates a promise that you can use for a single event.
 	 * @param event A event name
 	 */
-	public promise<E2 extends E, P extends unknown[] = Parameters<T[E2]>>(
+	public waitFor<E2 extends E, P extends unknown[] = Parameters<T[E2]>>(
 		event: E2,
 	): Promise<P> {
 		return new Promise<P>((resolve) => {

--- a/packages/client/libs/typed-event-emitter/index.ts
+++ b/packages/client/libs/typed-event-emitter/index.ts
@@ -41,4 +41,19 @@ export class TypedEventEmitter<
 
 		return this;
 	}
+
+	/**
+	 * Creating a promise, you can use it for once event.
+	 */
+	public promise<E2 extends E, P extends unknown[] = Parameters<T[E2]>>(
+		event: E2,
+	): Promise<P> {
+		return new Promise<P>((resolve) => {
+			const listener = ((...args) => {
+				this.off(event, listener);
+				resolve(args as P);
+			}) as T[E2];
+			this.on(event, listener);
+		});
+	}
 }


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

I added a `promise` method to TypedEventEmitter.
If you merged it, you can write code like that:
```ts
const [pin] = await client.promise('pincall')
```

## Checklist

- [x] Run tests (optional)
- [x] Add jsdoc (optional)
- [x] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.
