### PR TITLE
chore: remove deno fmt

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,14 +8,6 @@
 		"./storage": "./packages/storage/index.ts",
 		"./rate-limit": "./packages/rate-limit/index.ts"
 	},
-	"fmt": {
-		"indentWidth": 2,
-		"singleQuote": false,
-		"useTabs": true,
-		"exclude": [
-			"./docs/"
-		]
-	},
 	"imports": {
 		"@std/assert": "jsr:@std/assert@^1.0.2",
 		"curve25519-js": "npm:curve25519-js@^0.0.4",
@@ -24,7 +16,7 @@
 		"tweetnacl": "npm:tweetnacl@^1.0.3"
 	},
 	"tasks": {
-		"format": "deno fmt & deno run -A npm:@biomejs/biome format --write ./packages/**/*.ts",
+		"format": "deno run -A npm:@biomejs/biome format --write ./packages/**/*.ts",
 		"lint": "deno run -A npm:@biomejs/biome lint ./packages/**/*.ts",
 		"check": "deno run -A npm:@biomejs/biome check ./packages/**/*.ts"
 	}


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

In `deno task format`, biome calls after deno fmt calls. So codes formatted by deno are overrides. by biome. Therefore deno fmt is meaningless and you should remove it because it makes performance bottleneck.

## Checklist

- [ ] Run tests (optional)
- [ ] Add jsdoc (optional)
- [x] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.
