### PR TITLE
英語を、より見やすくより良くしました。

### DIFF
--- a/docs/docs/client-options.md
+++ b/docs/docs/client-options.md
@@ -11,7 +11,7 @@ const client = new Client({
 
 For example, **storage for the data** we talked about before, **OBS Endpoint**, **Endpoint** for communication, **customFetch** for cors and proxies, **RateLimitter** for rate limiting, etc.  
 
-Let me explain each one..
+Let me explain one by one.
 
 ## Storage
 

--- a/docs/docs/client-options.md
+++ b/docs/docs/client-options.md
@@ -1,6 +1,6 @@
 # Client Options
 
-Next we will talk about Client.  
+Next, we will talk about the Client.  
 The Client has several options.
 
 ```ts
@@ -11,7 +11,7 @@ const client = new Client({
 
 For example, **storage for the data** we talked about before, **OBS Endpoint**, **Endpoint** for communication, **customFetch** for cors and proxies, **RateLimitter** for rate limiting, etc.  
 
-Let me explain one by one.
+Let me explain each one..
 
 ## Storage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ hero:
   tagline: LINEJS is a JavaScript library for LINE SelfBot.
   actions:
     - theme: brand
-      text: See docs
+      text: See Docs
       link: /docs/start
     - theme: alt
       text: Examples
@@ -20,8 +20,8 @@ features:
     details: Node.js, Deno, Bun, and more.
   - title: Highly Typed
     icon: 🧩
-    details: Enhanced Typescript support.
+    details: Enhanced TypeScript support.
   - title: Safety Locked
     icon: 🔒
-    details: Defaults to safety locked. (RateLimit and others)
+    details: Defaults to safety locked (RateLimit and others).
 ---

--- a/packages/linejs/README.md
+++ b/packages/linejs/README.md
@@ -38,9 +38,8 @@ For now, please use "https://esm.sh/jsr/@evex/linejs".
 
 ## LINEJS Types
 
-Please see [@evex/linejs-types](https://jsr.io/@evex/linejs-types)\
-In short, TypeScript Types and Enum (ReactionType (0, 1, 2, 3), MessageType,
-etc...) are provided.
+Please see [@evex/linejs-types](https://jsr.io/@evex/linejs-types).  
+In short, TypeScript types and enums (such as ReactionType (0, 1, 2, 3), MessageType, etc.) are provided.
 
 ## Provided Packages
 


### PR DESCRIPTION
# 英語を、より見やすくより良くしました。

- READMEの英語を、少し統一しました。
- Docsのホーム画面の、See docsを、See Docsにしました。
- 同じくDocsのホーム画面の、TypescriptをTypeScriptにしました。
- ホーム画面のDefaults to safety locked. (RateLimit and others)を、Defaults to safety locked (RateLimit and others).に変更しました。
- docs/docs/client-options.mdの、Next we will talk about Client.を、Next, we will talk about the Client.にしました。
- 同じく、client-options.mdのLet me explain one by one.を、Let me explain each one..に変更しました。