### PR TITLE
fix sharedKey is null

### DIFF
--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -1,4 +1,4 @@
-import curve25519 from "curve25519-js";
+import {sharedKey} from "curve25519-js";
 import crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 import type { Location, Message } from "@evex/linejs-types";
@@ -264,7 +264,7 @@ export class E2EE {
 			privateKey: privateKey.length,
 			publicKey: publicKey.length,
 		});
-		return curve25519.sharedKey(
+		return sharedKey(
 			Uint8Array.from(privateKey),
 			Uint8Array.from(publicKey),
 		);


### PR DESCRIPTION
## Description
This PR fixes an issue where the curve25519-js module does not export a sharedKey function as expected.

The original implementation attempted to use curve25519.sharedKey(...), which resulted in the following runtime error:

```
{
  "error": "curve25519.sharedKey is not a function. (In 'curve25519.sharedKey(Uint8Array.from(privateKey), Uint8Array.from(publicKey))', 'curve25519.sharedKey' is undefined)"
}

```

The fix involves verifying the actual exports from curve25519-js, and using the correct method or switching to an alternative module like tweetnacl if necessary.