### PR TITLE
The high value of the pollingInterval is causing issues with real-time responsiveness.

### DIFF
--- a/packages/linejs/base/polling/mod.ts
+++ b/packages/linejs/base/polling/mod.ts
@@ -87,7 +87,7 @@ export class Polling {
 		pollingInterval?: number;
 	} = {}): AsyncGenerator<Operation, void, unknown> {
 		const { signal, onError, pollingInterval } = {
-			pollingInterval: 1000,
+			pollingInterval: 100,
 			...options,
 		};
 		while (true) {


### PR DESCRIPTION
This PR updates the `pollingInterval` value from 1000ms to 100ms to reduce data fetch latency and improve real-time responsiveness.

<!-- Thanks for your contribution -->

## Description

This PR updates the `pollingInterval` to enhance responsiveness in real-time data fetching.

Ideally, the shorter interval should result in faster updates.  
However, I haven't tested it in my own environment yet.  
I plan to test it later and, if needed, adjust the value in a separate PR.

## Checklist

- [ ] Run tests  
  *(Not tested personally — confirmed working by a friend with `pollingInterval = 100ms`)*
- [ ] Add jsdoc (optional)
- [ ] Test in your environment  
  *(Not tested in my own environment — verified by a friend)*

If you feel good :), please do the contents of the checklist.
