### PR TITLE
Fix Bug uploadObjTalk

### DIFF
--- a/packages/linejs/base/obs/mod.ts
+++ b/packages/linejs/base/obs/mod.ts
@@ -202,7 +202,7 @@ export class LineObs {
 		return await this.uploadObjectForService({
 			data,
 			oType: type,
-			obsPath: toType + "/m/" + oid || "reqseq",
+			obsPath: toType + "/m/" + (oid || "reqseq"),
 			filename: param.name,
 			params: param,
 		});


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

This PR fixes an operator precedence bug in `uploadObjTalk` that caused an invalid OBS upload path to be constructed when `oid` was not provided.

Due to the expression `toType + "/m/" + oid || "reqseq"`, uploads without `oid` were sent to paths such as `talk/m/undefined` or `g2/m/undefined`, resulting in empty `objId` and `objHash` values in the response.

The fix ensures that `"reqseq"` is correctly used as a fallback before path concatenation.

## Checklist

- [x] Run tests (optional)
- [x] Add jsdoc (optional)
- [x] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.