### PR TITLE
Fix Bug OBS uploadObjTalk

### DIFF
--- a/packages/linejs/base/obs/mod.ts
+++ b/packages/linejs/base/obs/mod.ts
@@ -169,6 +169,7 @@ export class LineObs {
 			);
 		}
 		const ext = MimeType[data.type as keyof typeof MimeType];
+		const reqseqValue = await this.client.getReqseq("talk");
 		const param: {
 			oid: string;
 			reqseq?: string;
@@ -185,7 +186,7 @@ export class LineObs {
 			...oid ? { oid: oid } : {
 				oid: "reqseq",
 				tomid: to,
-				reqseq: this.client.getReqseq("talk").toString(),
+				reqseq: reqseqValue.toString(),
 			},
 		};
 		if (type === "image") {


### PR DESCRIPTION
<!-- Thanks for your contribution -->

## Description

This PR fixes an issue where `getReqseq()` was used without `await` in `uploadObjTalk`.

Since `getReqseq()` returns a `Promise<number>`, calling `.toString()` on it resulted in an invalid string value (e.g. `"[object Promise]"`) being passed as `reqseq`.  
This caused incorrect request parameters when `oid` was not explicitly provided.

The fix ensures that `getReqseq()` is properly awaited before converting the value to a string.

The updated code was tested in my local environment and confirmed to work correctly.

## Checklist

- [x] Run tests (optional)
- [x] Add jsdoc (optional)
- [x] Test in your environment (optional)

If you feel good :), please do the contents of the checklist.