### PR TITLE
feat(push): internalize HTTP/2 fetch for the push module on Node.js

### DIFF
--- a/packages/linejs/base/push/conn.ts
+++ b/packages/linejs/base/push/conn.ts
@@ -7,6 +7,7 @@ import {
 	LegyH2SignOnResponseFrame,
 } from "./connData.ts";
 import type { ConnManager, ReadableStreamWriter } from "./connManager.ts";
+import { getH2EnabledFetchForNode } from "./h2_fetch.ts";
 import type { LooseType } from "@evex/loose-types";
 
 export class Conn {
@@ -106,17 +107,25 @@ export class Conn {
 		path: string,
 		headers: Record<string, string> = {},
 	) {
+		// LINE's push endpoint speaks HTTP/2 only. On Node.js the native
+		// fetch defaults to h1 and the stream silently never starts; we
+		// transparently swap in an undici-backed fetch with allowH2 just
+		// for this connection. On Deno/Bun/browser native fetch already
+		// does h2 and this lookup returns null, so the user's fetch is
+		// used as-is. See packages/linejs/base/push/h2_fetch.ts.
+		const fetchFn = (await getH2EnabledFetchForNode()) ??
+			this.client.fetch;
 		const bodystream = this.createAsyncReadableStream();
 		const abort = new AbortController();
 		await new Promise<void>((resolve) => {
 			(async () => {
-				const socket = await this.client.fetch(`https://${host}${path}`, {
+				const socket = await fetchFn(`https://${host}${path}`, {
 					method: "POST",
 					headers,
 					body: bodystream.stream,
 					signal: abort.signal,
 					// @ts-expect-error: https://github.com/evex-dev/linejs/issues/109
-					duplex: "half"
+					duplex: "half",
 				});
 				if (!socket.body) {
 					throw new Error("no body");
@@ -293,7 +302,8 @@ export class Conn {
 			}
 		} else {
 			throw new Error(
-				`PUSH not Implemented: type:${dt}, payloads:${bytesToHex(dd).slice(0, 30)
+				`PUSH not Implemented: type:${dt}, payloads:${
+					bytesToHex(dd).slice(0, 30)
 				}, len:${dd.length}`,
 			);
 		}

--- a/packages/linejs/base/push/h2_fetch.test.ts
+++ b/packages/linejs/base/push/h2_fetch.test.ts
@@ -1,0 +1,22 @@
+import { assert, assertEquals } from "@std/assert";
+import { getH2EnabledFetchForNode } from "./h2_fetch.ts";
+
+// On Deno (which is what this test runs under), getH2EnabledFetchForNode
+// must return null — Deno's native fetch already negotiates h2 via ALPN
+// and we explicitly skip the undici detour on non-Node runtimes.
+Deno.test("h2_fetch: returns null on Deno", async () => {
+	const f = await getH2EnabledFetchForNode();
+	assertEquals(f, null);
+});
+
+// Cached: invoking twice must not change the answer (and must not race —
+// the second call awaits the same Promise).
+Deno.test("h2_fetch: lookup is idempotent and stable", async () => {
+	const a = await getH2EnabledFetchForNode();
+	const b = await getH2EnabledFetchForNode();
+	assertEquals(a, b);
+	// On Deno both are null; the assertion above already covers that case.
+	// If we ever extend the function to also serve a Deno-specific fetch,
+	// this test stays meaningful as a stability check.
+	assert(a === null || typeof a === "function");
+});

--- a/packages/linejs/base/push/h2_fetch.ts
+++ b/packages/linejs/base/push/h2_fetch.ts
@@ -1,0 +1,87 @@
+/**
+ * @description Provide an HTTP/2-capable fetch for the LINE push endpoint on
+ * Node.js, without affecting the user's global fetch or BaseClient's
+ * normal RPC fetch.
+ *
+ * **Why this exists.** LINE's push endpoint serves bidirectional streaming
+ * over HTTP/2. The browser's native fetch, Deno's fetch, and Bun's fetch
+ * all negotiate h2 via TLS ALPN automatically. **Node.js's native fetch
+ * does not** — its bundled undici client defaults to HTTP/1.1 unless an
+ * h2-enabled Agent is installed as the dispatcher. Without that, the push
+ * subscription appears to connect but the server never starts the stream
+ * and consumers hang.
+ *
+ * Historically this was worked around in user code:
+ *
+ *     // example/node/allow_h2_for_push.ts
+ *     undici.setGlobalDispatcher(new undici.Agent({ allowH2: true }));
+ *
+ * That works but mutates the user's global fetch dispatcher, which is
+ * intrusive. This module replaces that pattern with a scoped solution: we
+ * lazily import undici only on Node, build an h2-enabled Agent, and
+ * expose a fetch wrapped to use that dispatcher per request. The push
+ * connection picks this up automatically; nothing else in the user's
+ * program is affected.
+ *
+ * **Runtime gates.**
+ *
+ *   - Deno / Bun / browser: native fetch already does h2 — we return null
+ *     and the caller falls back to client.fetch.
+ *   - Node without undici reachable: we return null. Push will degrade to
+ *     h1 (same as before) — the install just isn't fully fixed for that
+ *     user. They can either `npm i undici`, or pass a custom fetch to
+ *     BaseClient that already enables h2.
+ */
+import type { Fetch } from "../types.ts";
+
+let cached: Promise<Fetch | null> | null = null;
+
+function isNodeRuntime(): boolean {
+	if (typeof globalThis === "undefined") return false;
+	// Bun and Deno both set globals; checking those first avoids false
+	// positives on Bun, which exposes process.versions.node for compatibility.
+	if ("Bun" in globalThis) return false;
+	if ("Deno" in globalThis) return false;
+	const p = (globalThis as unknown as { process?: { versions?: { node?: string } } }).process;
+	return !!p?.versions?.node;
+}
+
+/** Returns an h2-capable fetch for Node, or null on every other runtime
+ *  (or on Node if undici can't be loaded). The result is cached for the
+ *  lifetime of the process; the Agent it wires up keeps an h2 connection
+ *  pool alive across push reconnects, which matches what the user code
+ *  in `example/node/allow_h2_for_push.ts` was doing with the global
+ *  dispatcher. */
+export function getH2EnabledFetchForNode(): Promise<Fetch | null> {
+	if (!isNodeRuntime()) return Promise.resolve(null);
+	if (cached) return cached;
+	cached = (async () => {
+		try {
+			// Dynamic import keeps undici out of the Deno/browser bundle and
+			// only pulls it in if push is actually used on Node.
+			const undici = await import("undici");
+			// We treat undici's surface as `unknown` and re-narrow because
+			// its Response/Request types diverge from the global Web ones
+			// (e.g. undici@7's Response lacks the WHATWG `bytes()` method
+			// declared in Deno's lib.deno.fetch.d.ts). The push consumer
+			// only ever reads `.body`, which both shapes implement.
+			const u = undici as unknown as {
+				Agent: new (opts: { allowH2: boolean }) => unknown;
+				fetch: (
+					input: unknown,
+					init?: Record<string, unknown>,
+				) => Promise<unknown>;
+			};
+			const agent = new u.Agent({ allowH2: true });
+			const wrap: Fetch = (info, init) =>
+				u.fetch(info, {
+					...(init as Record<string, unknown> | undefined),
+					dispatcher: agent,
+				}) as unknown as Promise<Response>;
+			return wrap;
+		} catch {
+			return null;
+		}
+	})();
+	return cached;
+}

--- a/packages/linejs/deno.json
+++ b/packages/linejs/deno.json
@@ -19,6 +19,7 @@
 		"tweetnacl": "npm:tweetnacl@^1.0.3",
 		"jsdom": "npm:jsdom@25.0.0",
 		"node-types": "npm:@types/node@latest",
-		"node-int64": "npm:node-int64@^0.4.0"
+		"node-int64": "npm:node-int64@^0.4.0",
+		"undici": "npm:undici@^7"
 	}
 }


### PR DESCRIPTION
## Description

Internalize the HTTP/2 fetch handling that previously required users to import \`example/node/allow_h2_for_push.ts\` (or otherwise set a global undici dispatcher) to receive push events on Node.

LINE's push endpoint serves bidirectional streaming over h2. Deno/Bun/browser fetch negotiate h2 via TLS ALPN automatically; Node.js's native fetch defaults to h1, so push silently never starts. This PR scopes an h2-capable fetch to the push module so users no longer have to patch their global fetch.

### Implementation

- New \`packages/linejs/base/push/h2_fetch.ts\`: lazy, runtime-gated factory. On Node it \`import()\`s undici, builds an \`Agent({ allowH2: true })\`, and returns a wrapped fetch that uses it as dispatcher. The result is cached for the process lifetime so the h2 connection pool persists across reconnects (which is what the global-dispatcher example was achieving).
- Bun / Deno / browser: \`getH2EnabledFetchForNode()\` returns \`null\` and \`conn.ts\` falls back to \`client.fetch\` (their native fetch already does h2 over ALPN).
- \`conn.ts\`: use the h2-capable fetch when available, otherwise client.fetch. No global mutation, no replacement of the user's custom fetch elsewhere.
- \`packages/linejs/deno.json\` adds \`"undici": "npm:undici@^7"\` so the dynamic import resolves on both Deno (via deno.json) and Node (via JSR's generated npm dependency).
- New \`packages/linejs/base/push/h2_fetch.test.ts\` confirms the runtime gate (returns null on Deno) and that the lookup is idempotent.
- \`example/node/allow_h2_for_push.ts\` is kept as-is for users who'd rather configure the global dispatcher themselves.

### Properties

- **Non-invasive**: doesn't touch \`globalThis.fetch\` or \`globalThis.Request\`.
- **Conservative runtime detection**: Bun (\`globalThis.Bun\`) and Deno (\`globalThis.Deno\`) are checked before the Node \`process.versions.node\` test.
- **Soft-fail**: if undici can't be loaded, the helper returns null and push degrades to today's behavior rather than crashing.

## Checklist

- [x] Run tests (\`deno test\` — 3 passed, including the two new \`h2_fetch\` tests)
- [x] Add jsdoc (h2_fetch.ts is thoroughly documented)
- [x] Test in your environment (Deno; the Node detection branch needs Node-side runtime verification)

Closes #127