### PR TITLE
feat(client): User.fetchCalendarEvents + Chat.getBgm/setBgm

### DIFF
--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -187,6 +187,7 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 		});
 		const raw = res.responses[0];
 		return new User({
+			client: this,
 			raw,
 		});
 	}

--- a/packages/linejs/client/features/chat/mod.ts
+++ b/packages/linejs/client/features/chat/mod.ts
@@ -158,4 +158,32 @@ export class Chat {
 	messageFetcher(): Promise<MessageFetcher> {
 		return createMessageFetcher(this.#client, this);
 	}
+
+	/**
+	 * Fetches the BGM (chat background music) currently set on this chat,
+	 * or `undefined` if none is set.
+	 *
+	 * Backed by `Talk.getChatRoomBGMs`, which is a batch RPC; this is the
+	 * single-chat convenience.
+	 */
+	async getBgm(): Promise<line.ChatRoomBGM | undefined> {
+		const res = await this.#client.base.talk.getChatRoomBGMs({
+			chatRoomMids: [this.mid],
+		});
+		return res?.[this.mid];
+	}
+
+	/**
+	 * Sets (or clears) the BGM on this chat.  Pass a string `bgmInfo` to
+	 * set, or `null` to clear.  The `bgmInfo` encoding (LINE MUSIC track
+	 * id etc.) is opaque to linejs and is round-tripped to the server as-
+	 * is.
+	 */
+	async setBgm(bgmInfo: string | null): Promise<line.ChatRoomBGM> {
+		return await this.#client.base.talk.updateChatRoomBGM({
+			reqSeq: await this.#client.base.getReqseq(),
+			chatRoomMid: this.mid,
+			chatRoomBGMInfo: bgmInfo ?? "",
+		});
+	}
 }

--- a/packages/linejs/client/features/user/mod.ts
+++ b/packages/linejs/client/features/user/mod.ts
@@ -1,14 +1,58 @@
-import type { GetContactV3Response } from "@evex/linejs-types";
+import type * as line from "@evex/linejs-types";
+import type { Client } from "../../mod.ts";
 
 export interface UserInit {
-	raw: GetContactV3Response;
+	client?: Client;
+	raw: line.GetContactV3Response;
 }
 
 export class User {
+	#client?: Client;
 	readonly mid: string;
-	readonly raw: GetContactV3Response;
+	readonly raw: line.GetContactV3Response;
 	constructor(init: UserInit) {
+		this.#client = init.client;
 		this.mid = init.raw.targetUserMid;
 		this.raw = init.raw;
+	}
+
+	/**
+	 * Fetches this user's contact calendar events (e.g. birthday) via
+	 * `getContactCalendarEvents`.  Requires the User to have been
+	 * constructed with a Client.
+	 */
+	async fetchCalendarEvents(
+		eventKinds?: line.GetContactCalendarEventsRequest["requiredContactCalendarEvents"],
+	): Promise<line.ContactCalendarEvent[]> {
+		const client = this.#requireClient("fetchCalendarEvents");
+		const res = await client.base.relation.getContactCalendarEvents({
+			request: {
+				targetUsers: [{ targetUserMid: this.mid }],
+				requiredContactCalendarEvents: eventKinds,
+			},
+		});
+		const entry = res.responses.find((r) => r.targetUserMid === this.mid);
+		// NOTE: `ContactCalendarEvents.events` is missing a value-type in
+		// the synced Thrift schema (apk-sync leaves it as a bare key:8).
+		// Until the schema is fixed we treat the payload structurally and
+		// reach in through `unknown`.
+		const events =
+			(entry?.ContactCalendarEvents as unknown as { events?: unknown })
+				?.events;
+		if (Array.isArray(events)) return events as line.ContactCalendarEvent[];
+		if (events && typeof events === "object") {
+			return Object.values(events) as line.ContactCalendarEvent[];
+		}
+		return [];
+	}
+
+	#requireClient(method: string): Client {
+		if (!this.#client) {
+			throw new Error(
+				`User.${method}() requires a Client. ` +
+					`Construct User with { client, raw } to enable RPC helpers.`,
+			);
+		}
+		return this.#client;
 	}
 }


### PR DESCRIPTION
## Description

Adds high-level wrappers on the User and Chat feature classes for two RPC surfaces that were already generated as base services in #139 but not yet exposed at the right level of abstraction:

### Calendar events
\`User.fetchCalendarEvents(kinds?)\` calls \`relation.getContactCalendarEvents\` and returns this user's events (e.g. birthday).

\`\`\`ts
const user = await client.getUser(\"u...\");
const events = await user.fetchCalendarEvents();
\`\`\`

### Chat BGM
\`Chat.getBgm()\` / \`Chat.setBgm(info | null)\` wrap \`talk.getChatRoomBGMs\` and \`talk.updateChatRoomBGM\`.

\`\`\`ts
const chat = await client.getChat(\"c...\");
const current = await chat.getBgm();
await chat.setBgm(\"<LINE MUSIC track id>\");
await chat.setBgm(null); // clear
\`\`\`

## Notes

- \`User\` now optionally carries a \`client\` reference so its instance methods can issue RPCs.  Plumbed through \`getUser\`.
- \`ContactCalendarEvents.events\` is missing its value-type in the synced Thrift schema (empty interface at \`line_types.ts:9156\`).  Worked around defensively for now; filed as a separate fix so apk-sync can recover it from smali.

## Checklist

- [x] Run tests (4 passed)
- [x] Type check (deno check packages/linejs/client/mod.ts)
- [x] Add jsdoc on new methods