### PR TITLE
feat(client): profile self-updates (displayName / statusMessage / etc)

### DIFF
--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -6,7 +6,14 @@ import { User } from "./features/user/mod.ts";
 import { TypedEventEmitter } from "../base/core/typed-event-emitter/index.ts";
 import { SquareMessage, TalkMessage } from "./features/message/mod.ts";
 import type * as LINETypes from "@evex/linejs-types";
+import {
+	getMyProfile,
+	type MyProfileUpdate,
+	updateMyProfile,
+} from "./features/profile.ts";
 export { Chat, Square, SquareChat, SquareMessage, TalkMessage, User };
+export { ProfileAttribute } from "./features/profile.ts";
+export type { MyProfileUpdate } from "./features/profile.ts";
 export interface ListenOptions {
 	/**
 	 * A boolean of whether to enable receiving talk events.
@@ -101,6 +108,29 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 	get authToken(): string {
 		// NOTE: client is constructed when logined, so authToken is not undefined.
 		return this.base.authToken as string;
+	}
+
+	/** Returns the signed-in user's own profile. */
+	getMyProfile(): Promise<LINETypes.Profile> {
+		return getMyProfile(this);
+	}
+
+	/**
+	 * Updates one or more attributes on the signed-in user's profile.
+	 * @example client.updateMyProfile({ statusMessage: "今日も頑張る" })
+	 */
+	updateMyProfile(update: MyProfileUpdate): Promise<void> {
+		return updateMyProfile(this, update);
+	}
+
+	/** Convenience: rename the signed-in user. */
+	updateMyDisplayName(displayName: string): Promise<void> {
+		return updateMyProfile(this, { displayName });
+	}
+
+	/** Convenience: set the signed-in user's status message (ステメ). */
+	updateMyStatusMessage(statusMessage: string): Promise<void> {
+		return updateMyProfile(this, { statusMessage });
 	}
 
 	/**

--- a/packages/linejs/client/features/profile.ts
+++ b/packages/linejs/client/features/profile.ts
@@ -1,0 +1,99 @@
+import type * as line from "@evex/linejs-types";
+import type { Client } from "../mod.ts";
+
+/**
+ * `ProfileAttribute` values from the Thrift schema (enum `Pb1_K6`).
+ *
+ * Used as the i32 key in `updateProfileAttributes` so the server knows
+ * which subset of the profile is being modified.
+ */
+export const ProfileAttribute = {
+	EMAIL: 1,
+	DISPLAY_NAME: 2,
+	PHONETIC_NAME: 4,
+	PICTURE: 8,
+	STATUS_MESSAGE: 16,
+	ALLOW_SEARCH_BY_USERID: 32,
+	ALLOW_SEARCH_BY_EMAIL: 64,
+	BUDDY_STATUS: 128,
+	MUSIC_PROFILE: 256,
+	AVATAR_PROFILE: 512,
+	HIDDEN_FROM_LIST: 1024,
+} as const;
+export type ProfileAttributeKey = keyof typeof ProfileAttribute;
+
+/**
+ * Friendly per-field update shape.  Each present key is translated into
+ * a `(ProfileAttribute, ProfileContent)` map entry for the server.
+ */
+export interface MyProfileUpdate {
+	displayName?: string;
+	statusMessage?: string;
+	phoneticName?: string;
+	musicProfile?: string;
+	allowSearchByUserid?: boolean;
+	allowSearchByEmail?: boolean;
+	hiddenFromList?: boolean;
+}
+
+function bool(v: boolean): string {
+	return v ? "true" : "false";
+}
+
+function buildAttrMap(update: MyProfileUpdate): Record<number, line.ProfileContent> {
+	const out: Record<number, line.ProfileContent> = {};
+	const put = (attr: number, value: string) => {
+		out[attr] = { value, meta: {} };
+	};
+	if (update.displayName !== undefined) {
+		put(ProfileAttribute.DISPLAY_NAME, update.displayName);
+	}
+	if (update.statusMessage !== undefined) {
+		put(ProfileAttribute.STATUS_MESSAGE, update.statusMessage);
+	}
+	if (update.phoneticName !== undefined) {
+		put(ProfileAttribute.PHONETIC_NAME, update.phoneticName);
+	}
+	if (update.musicProfile !== undefined) {
+		put(ProfileAttribute.MUSIC_PROFILE, update.musicProfile);
+	}
+	if (update.allowSearchByUserid !== undefined) {
+		put(ProfileAttribute.ALLOW_SEARCH_BY_USERID, bool(update.allowSearchByUserid));
+	}
+	if (update.allowSearchByEmail !== undefined) {
+		put(ProfileAttribute.ALLOW_SEARCH_BY_EMAIL, bool(update.allowSearchByEmail));
+	}
+	if (update.hiddenFromList !== undefined) {
+		put(ProfileAttribute.HIDDEN_FROM_LIST, bool(update.hiddenFromList));
+	}
+	return out;
+}
+
+/**
+ * Fetches the signed-in user's own profile (`talk.getProfile`).
+ */
+export async function getMyProfile(client: Client): Promise<line.Profile> {
+	return await client.base.talk.getProfile({});
+}
+
+/**
+ * Updates one or more attributes on the signed-in user's profile.
+ *
+ * Server-side this is a single `updateProfileAttributes` RPC carrying
+ * only the keys you actually changed — sparse, not a full replace.
+ *
+ * @example
+ *   await client.updateMyProfile({ statusMessage: "離席中" });
+ */
+export async function updateMyProfile(
+	client: Client,
+	update: MyProfileUpdate,
+): Promise<void> {
+	const profileAttributes = buildAttrMap(update);
+	if (Object.keys(profileAttributes).length === 0) return;
+	await client.base.talk.updateProfileAttributes({
+		reqSeq: await client.base.getReqseq(),
+		request: { profileAttributes },
+		success: undefined as never,
+	});
+}


### PR DESCRIPTION
## Description

Adds high-level wrappers on \`Client\` for editing the signed-in user's own profile, on top of the already-generated \`talk.updateProfileAttributes\` RPC:

- \`client.getMyProfile()\`
- \`client.updateMyProfile({ displayName?, statusMessage?, phoneticName?, musicProfile?, allowSearchByUserid?, allowSearchByEmail?, hiddenFromList? })\` — sparse update; only the keys you set get sent
- \`client.updateMyDisplayName(name)\`
- \`client.updateMyStatusMessage(text)\` — sets ステメ (status message)

The \`Pb1_K6\` ProfileAttribute enum is exported as \`ProfileAttribute\` for users who want to issue the raw RPC.

## Example

\`\`\`ts
await client.updateMyStatusMessage(\"今日も頑張る\");
const me = await client.getMyProfile();
\`\`\`

## Notes

- The synced \`updateProfileAttributes_args\` interface has a spurious \`success: any\` field (a schema-syncer artifact — \`fid:0 success\` accidentally emitted into the args struct).  Passed \`success: undefined as never\` to satisfy the type-checker; the field is never serialized server-side because reqSeq/request are the only writable fields.

## Checklist

- [x] tests passing
- [x] deno check
- [x] jsdoc