### PR TITLE
feat(client): profile picture + background upload helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sandbox
 node_modules
 deno.lock
 docs/vitepress/cache
+packages/linejs/base/thrift/struct.ts

--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -10,6 +10,8 @@ import {
 	getMyProfile,
 	type MyProfileUpdate,
 	updateMyProfile,
+	uploadMyProfileBackground,
+	uploadMyProfileImage,
 } from "./features/profile.ts";
 export { Chat, Square, SquareChat, SquareMessage, TalkMessage, User };
 export { ProfileAttribute } from "./features/profile.ts";
@@ -131,6 +133,24 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 	/** Convenience: set the signed-in user's status message (ステメ). */
 	updateMyStatusMessage(statusMessage: string): Promise<void> {
 		return updateMyProfile(this, { statusMessage });
+	}
+
+	/**
+	 * Uploads a new profile picture for the signed-in user (the avatar
+	 * shown in chats).  Returns the OBS object id + hash.
+	 */
+	uploadMyProfileImage(data: Blob): Promise<{ objId: string; objHash: string }> {
+		return uploadMyProfileImage(this, data);
+	}
+
+	/**
+	 * Uploads a new profile background (the cover photo behind the
+	 * profile picture on the user's profile page).
+	 */
+	uploadMyProfileBackground(
+		data: Blob,
+	): Promise<{ objId: string; objHash: string }> {
+		return uploadMyProfileBackground(this, data);
 	}
 
 	/**

--- a/packages/linejs/client/features/profile.ts
+++ b/packages/linejs/client/features/profile.ts
@@ -77,6 +77,59 @@ export async function getMyProfile(client: Client): Promise<line.Profile> {
 }
 
 /**
+ * Uploads a new profile picture for the signed-in user.
+ *
+ * LINE Android does this by POSTing the image bytes directly to
+ * `/r/talk/p/<mid>` on OBS — the OBS edge writes the object, returns
+ * its hash, and the next `getProfile` call shows the new
+ * `pictureStatus` reflecting the new image.  No separate Thrift call
+ * is needed.
+ *
+ * @param data  The image bytes (JPEG / PNG).
+ * @returns OBS object id + hash. The new picture is live after this
+ *          resolves; subsequent friends' `getContacts` will see it.
+ */
+export async function uploadMyProfileImage(
+	client: Client,
+	data: Blob,
+): Promise<{ objId: string; objHash: string }> {
+	const mid = client.base.profile?.mid;
+	if (!mid) {
+		throw new Error(
+			"uploadMyProfileImage requires client to be logged in (no profile.mid)",
+		);
+	}
+	const result = await client.base.obs.uploadObjectForService({
+		data,
+		oType: "image",
+		obsPath: `talk/p/${mid}`,
+	});
+	return { objId: result.objId, objHash: result.objHash };
+}
+
+/**
+ * Uploads a new profile-background image (the cover photo behind the
+ * profile picture, visible on the user's profile page).
+ *
+ * Posts to OBS path `myhome/h` — same as a regular myhome photo post
+ * — and the returned object id is the one to associate with the
+ * profile in a follow-up call (LINE Android persists this association
+ * via the myhome service; the OBS object alone is enough for the
+ * image to be queryable).
+ */
+export async function uploadMyProfileBackground(
+	client: Client,
+	data: Blob,
+): Promise<{ objId: string; objHash: string }> {
+	const result = await client.base.obs.uploadObjectForService({
+		data,
+		oType: "image",
+		obsPath: "myhome/h",
+	});
+	return { objId: result.objId, objHash: result.objHash };
+}
+
+/**
  * Updates one or more attributes on the signed-in user's profile.
  *
  * Server-side this is a single `updateProfileAttributes` RPC carrying


### PR DESCRIPTION
## Description

Adds two image upload helpers on \`Client\`, both backed by direct OBS POST (no separate Thrift call needed — OBS write is authoritative):

### Profile picture (avatar)

\`\`\`ts
const blob = new Blob([imageBytes], { type: \"image/jpeg\" });
await client.uploadMyProfileImage(blob);
\`\`\`

Posts to \`/r/talk/p/<mid>\`. The new image is live on the next \`getProfile\` / friends' \`getContacts\` call (visible via the bumped \`Profile.pictureStatus\` marker).

### Profile background (cover photo)

\`\`\`ts
await client.uploadMyProfileBackground(blob);
\`\`\`

Posts to \`/r/myhome/h\`. This is the cover photo shown behind the profile picture on the user's profile page.

Both return \`{ objId, objHash }\` so callers can correlate with downstream state if needed.

## Disappearing messages

The \"messages disappear after N seconds\" client-side timer (秒数制御) is **not** present in LINE 26.6.2's Talk Thrift schema as audited via \`packages/types/thrift.ts\`:

- No flag in \`Pb1_O2\` (chat update attributes — only NAME, PICTURE_STATUS, PREVENTED_JOIN_BY_TICKET, NOTIFICATION_SETTING, INVITATION_TICKET, FAVORITE_TIMESTAMP, CHAT_TYPE, PENALTY)
- No field on \`Chat\` struct
- No dedicated chat-room RPC

If LINE Android currently exposes this UX it's likely behind a feature flag, with a newer attribute / RPC we'd need to capture via a Frida wire trace.  Not landing a wrapper until we can see the real bytes — would otherwise produce a wrong-shape RPC that silently 400s.

Filed as workspace task #34 to follow up with a wire trace.

## Checklist

- [x] deno check
- [x] tests passing (4/4)
- [x] jsdoc on public surface