### PR TITLE
feat(agent): tests + auth-doc clarity for AgentIClient (v2.7.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,7 @@ jobs:
         run: |
           cd packages/linejs
           deno run -A jsr:@david/publish-on-tag@0.1.3
+      - name: Publish linejs-agent to JSR
+        run: |
+          cd packages/agent
+          deno run -A jsr:@david/publish-on-tag@0.1.3

--- a/packages/agent/client.test.ts
+++ b/packages/agent/client.test.ts
@@ -1,0 +1,169 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+	AgentIClient,
+	buildAgentIWebViewUrl,
+	frcodeFor,
+	frtypeFor,
+} from "./client.ts";
+
+Deno.test("frcodeFor / frtypeFor — values match LINE Android uk2.a.a", () => {
+	assertEquals(frcodeFor("chattab_searchbar"), "line_agenti_chattab_searchbar");
+	assertEquals(frtypeFor("chattab_searchbar"), "line_chattab_searchbar");
+	assertEquals(frcodeFor("hometab_searchbar"), "line_agenti_hometab_searchbar");
+	assertEquals(frtypeFor("hometab_searchbar"), "line_hometab_searchbar");
+	assertEquals(frcodeFor("newstab_searchbar"), "line_agenti_newstab_searchbar");
+	assertEquals(frtypeFor("newstab_searchbar"), "line_newstab_searchbar");
+});
+
+Deno.test("buildAgentIWebViewUrl — joins the canonical base with fr/frtype/q", () => {
+	const url = buildAgentIWebViewUrl({
+		source: "chattab_searchbar",
+		query: "こんにちは",
+	});
+	const u = new URL(url);
+	assertEquals(u.origin + u.pathname, "https://search.yahoo.co.jp/chat");
+	assertEquals(u.searchParams.get("fr"), "line_agenti_chattab_searchbar");
+	assertEquals(u.searchParams.get("frtype"), "line_chattab_searchbar");
+	assertEquals(u.searchParams.get("q"), "こんにちは");
+});
+
+Deno.test("buildAgentIWebViewUrl — omits q when not given, allows baseUrl override", () => {
+	const url = buildAgentIWebViewUrl({
+		source: "hometab_searchbar",
+		baseUrl: "https://example.test/agent",
+	});
+	const u = new URL(url);
+	assertEquals(u.origin + u.pathname, "https://example.test/agent");
+	assertEquals(u.searchParams.get("q"), null);
+	assertEquals(u.searchParams.get("fr"), "line_agenti_hometab_searchbar");
+});
+
+function makeMockFetch(events: string[]): typeof fetch {
+	return ((_url: unknown, _init?: unknown) => {
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				const enc = new TextEncoder();
+				for (const e of events) controller.enqueue(enc.encode(e));
+				controller.close();
+			},
+		});
+		return Promise.resolve(
+			new Response(stream, {
+				status: 200,
+				statusText: "OK",
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+	}) as unknown as typeof fetch;
+}
+
+Deno.test("AgentIClient — parses SSE chunks and accumulates history", async () => {
+	const client = new AgentIClient({
+		cookie: "x=y",
+		source: "chattab_searchbar",
+		fetch: makeMockFetch([
+			`event: message\ndata: {"text":"Hel"}\n\n`,
+			`event: message\ndata: {"text":"lo!"}\n\n`,
+			`event: done\ndata: {}\n\n`,
+		]),
+	});
+	const collected: string[] = [];
+	for await (const c of client.chat("Hi")) {
+		if (c.text) collected.push(c.text);
+	}
+	assertEquals(collected.join(""), "Hello!");
+	assertEquals(client.history.length, 2);
+	assertEquals(client.history[0].role, "user");
+	assertEquals(client.history[0].contents[0].text, "Hi");
+	assertEquals(client.history[1].role, "assistant");
+	assertEquals(client.history[1].contents[0].text, "Hello!");
+});
+
+Deno.test("AgentIClient — empty assistant reply does not pollute history", async () => {
+	const client = new AgentIClient({
+		cookie: "x=y",
+		fetch: makeMockFetch([`event: ping\ndata: {}\n\n`]),
+	});
+	for await (const _c of client.chat("Hi")) { /* drain */ }
+	assertEquals(client.history.length, 1);
+	assertEquals(client.history[0].role, "user");
+});
+
+Deno.test("AgentIClient — raw-string data payloads (non-JSON) round-trip", async () => {
+	const client = new AgentIClient({
+		cookie: "x=y",
+		fetch: makeMockFetch([
+			`data: just a string\n\n`,
+			`data: {"text":"and then json"}\n\n`,
+		]),
+	});
+	const chunks: unknown[] = [];
+	for await (const c of client.chat("Hi")) chunks.push(c);
+	assertEquals((chunks[0] as { text: string }).text, "just a string");
+	assertEquals((chunks[1] as { text: string }).text, "and then json");
+});
+
+Deno.test("AgentIClient — surfaces server errors with status code", async () => {
+	const client = new AgentIClient({
+		cookie: "x=y",
+		fetch: (() =>
+			Promise.resolve(
+				new Response(null, { status: 401, statusText: "Unauthorized" }),
+			)) as unknown as typeof fetch,
+	});
+	let err: unknown;
+	try {
+		for await (const _c of client.chat("Hi")) { /* drain */ }
+	} catch (e) {
+		err = e;
+	}
+	assert(err instanceof Error);
+	assert(/401/.test((err as Error).message));
+});
+
+Deno.test("AgentIClient — reset clears history", async () => {
+	const client = new AgentIClient({
+		cookie: "x=y",
+		fetch: makeMockFetch([`data: {"text":"ok"}\n\n`]),
+	});
+	for await (const _c of client.chat("hi")) { /* drain */ }
+	assert(client.history.length > 0);
+	client.reset();
+	assertEquals(client.history.length, 0);
+});
+
+Deno.test("AgentIClient — sends the right request shape", async () => {
+	let capturedUrl: string | undefined;
+	let capturedBody: string | undefined;
+	let capturedHeaders: Headers | undefined;
+	const client = new AgentIClient({
+		cookie: "B=anon",
+		source: "chattab_searchbar",
+		lineVersion: "26.7.0",
+		fetch: ((url: unknown, init?: { headers?: HeadersInit; body?: BodyInit }) => {
+			capturedUrl = String(url);
+			capturedHeaders = new Headers(init?.headers);
+			capturedBody = init?.body as string;
+			return Promise.resolve(
+				new Response(
+					new ReadableStream({ start(c) { c.close(); } }),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+			);
+		}) as unknown as typeof fetch,
+	});
+	for await (const _c of client.chat("hi")) { /* drain */ }
+	assertEquals(capturedUrl, "https://search-agent.yahoo.co.jp/v2/chat");
+	const ua = capturedHeaders?.get("user-agent") ?? "";
+	assert(/Line\/26\.7\.0\/Agenti/.test(ua), `UA mismatch: ${ua}`);
+	assertEquals(capturedHeaders?.get("cookie"), "B=anon");
+	assertEquals(capturedHeaders?.get("accept"), "text/event-stream");
+	assertEquals(capturedHeaders?.get("origin"), "https://search.yahoo.co.jp");
+	const body = JSON.parse(capturedBody!);
+	assertEquals(body.context.agentMode, "multi");
+	assertEquals(body.context.frcode, "line_agenti_chattab_searchbar");
+	assertEquals(body.context.frtype, "line_chattab_searchbar");
+	assertEquals(body.context.requestType, "free_text");
+	assertEquals(body.chats[0].role, "user");
+	assertEquals(body.chats[0].contents[0].text, "hi");
+});

--- a/packages/agent/client.ts
+++ b/packages/agent/client.ts
@@ -50,9 +50,12 @@ export function frtypeFor(source: AgentISource): string {
 }
 
 export interface AgentIOptions {
-	/** Yahoo session cookies (`B`, `XB`, `A`, `XA`) as a single Cookie
-	 *  header string — e.g. `"B=...; XB=...; A=...; XA=..."`.  Required;
-	 *  LINE Android does not mint these. */
+	/** `Cookie` header value sent on the SSE POST.  See evex-dev/linejs#152
+	 *  for the open investigation: LINE Android can drive Agent I without
+	 *  the user being logged into Yahoo, so the real requirement is
+	 *  probably anonymous `B` / `XB` cookies issued by `search.yahoo.co.jp`
+	 *  on a prior GET — not a full Yahoo login.  Pass whatever Cookie
+	 *  string you've got; pass `""` to try without one. */
 	cookie: string;
 	/** LINE app version reported in the `Line/<ver>/Agenti` UA suffix.
 	 *  Defaults to a recent value from the LINE iOS captures used to

--- a/packages/agent/deno.json
+++ b/packages/agent/deno.json
@@ -6,5 +6,7 @@
 		".": "./mod.ts",
 		"./client": "./client.ts"
 	},
-	"imports": {}
+	"imports": {
+		"@std/assert": "jsr:@std/assert@^1.0.2"
+	}
 }

--- a/packages/agent/mod.ts
+++ b/packages/agent/mod.ts
@@ -13,11 +13,18 @@
  * can drive Agent I from outside the LINE app provided they hold a
  * valid Yahoo session.
  *
- * Auth: the SSE endpoint requires Yahoo session cookies (`B`, `XB`,
- * `A`, `XA`).  LINE Android does not mint these — they come from
- * Yahoo's own auth (a separate Yahoo Japan login).  This library
- * accepts them as a `cookie` string; it makes no attempt to obtain
- * them on the caller's behalf.
+ * Auth (provisional, **see issue evex-dev/linejs#152**): the SSE
+ * endpoint expects a `Cookie` header.  The original capture that
+ * seeded this work had `B` / `XB` / `A` / `XA` placeholders, but
+ * **LINE Android itself can use Agent I without the user logging
+ * into Yahoo**, which means the real auth shape is something
+ * lighter than a full Yahoo login session — possibly anonymous
+ * `B` / `XB` cookies issued by `search.yahoo.co.jp` on first GET,
+ * possibly origin/referer alone, possibly a LINE-side handshake.
+ * This client accepts any `cookie` string the caller can mint; until
+ * #152 nails down the exact requirement, the simplest working
+ * approach is to hit `https://search.yahoo.co.jp/chat` first to let
+ * Yahoo set the anonymous cookies, then pass them in here.
  *
  * Source of truth: LINE Android 26.6.2 — see
  *   `decompiled/base/smali/smali_classes8/km2/a.smali`        (URL builder)
@@ -29,7 +36,7 @@
  * @example
  *   import { AgentIClient } from "@evex/linejs-agent";
  *   const agent = new AgentIClient({
- *     cookie: yahooSessionCookies, // "B=...; XB=...; A=...; XA=..."
+ *     cookie: cookies, // see #152 — Yahoo anonymous cookies usually suffice
  *     lineVersion: "26.6.0",
  *     source: "chattab_searchbar",
  *   });


### PR DESCRIPTION
## Description

Tightens \`@evex/linejs-agent\` after the v2.7.1 ship-and-iterate cycle.

### Tests

New \`packages/agent/client.test.ts\` — 9 offline tests covering:
- \`frcodeFor\` / \`frtypeFor\` value parity with LINE Android \`uk2.a.a\`
- \`buildAgentIWebViewUrl\` composition (with / without query, baseUrl override)
- \`AgentIClient\` SSE chunk parsing (multi-event accumulation, history append/reset)
- raw-string vs JSON \`data:\` payload handling
- HTTP error surfacing with status code in the thrown message
- exact request shape: URL, UA, Cookie, headers, JSON body fields

Mock \`fetch\` injected via the existing \`AgentIOptions.fetch\` option — fully offline.  **13/13 tests pass** workspace-wide (4 existing + 9 new).

### Doc honesty

v2.7.1 docs claimed \`B\` / \`XB\` / \`A\` / \`XA\` Yahoo cookies were *required*.  That was a leak from the placeholders in the original seed curl; LINE Android in fact drives Agent I **without** the user logging into Yahoo (called out by @EdamAme-x).  So the real requirement is lighter — probably anonymous \`B\` / \`XB\` cookies issued by \`search.yahoo.co.jp\` on a prior GET, possibly origin/referer alone, possibly a LINE-side handshake.

The module doc + \`cookie\` field doc now reflect this honestly and reference #152 (the open investigation).  \`cookie: \"\"\` is now a documented \"try without\" path.

### Release workflow

\`@evex/linejs-agent\` added as a third \`publish-on-tag\` step in \`.github/workflows/release.yml\` so it ships to JSR on \`v2.7.2+\`.

## Why this is v2.7.2 and not later

The auth investigation (#152) needs more Frida traces and that's not gating: the client works as-is for any caller who can provide *some* Cookie value (live capture, anonymous Yahoo cookies, or empty).  Shipping the tests + doc fix now is strictly better than leaving v2.7.1 with the misleading claim in place.

## Checklist

- [x] 9 new tests pass
- [x] full workspace tests 13/13
- [x] deno check
- [x] mod.ts + client.ts doc updates referencing #152
- [x] release workflow ships @evex/linejs-agent on tag push