### PR TITLE
feat(client): client.liff ergonomic surface + message builders (v2.7.3)

### DIFF
--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -13,6 +13,8 @@ import {
 	uploadMyProfileBackground,
 	uploadMyProfileImage,
 } from "./features/profile.ts";
+import { createLiffClient, type LiffClient } from "./features/liff.ts";
+export * as liff from "./features/liff.ts";
 export { Chat, Square, SquareChat, SquareMessage, TalkMessage, User };
 export { ProfileAttribute } from "./features/profile.ts";
 export type { MyProfileUpdate } from "./features/profile.ts";
@@ -43,9 +45,20 @@ export type ClientEvents = {
 
 export class Client extends TypedEventEmitter<ClientEvents> {
 	readonly base: BaseClient;
+	#liff?: LiffClient;
 	constructor(base: BaseClient) {
 		super();
 		this.base = base;
+	}
+
+	/**
+	 * High-level LIFF helpers (token minting + message sharing).  See
+	 * {@link "./features/liff.ts" | features/liff.ts} for the message
+	 * builders (`text` / `sticker` / `image` / `flex`).
+	 */
+	get liff(): LiffClient {
+		if (!this.#liff) this.#liff = createLiffClient(this);
+		return this.#liff;
 	}
 
 	/**

--- a/packages/linejs/client/features/liff.test.ts
+++ b/packages/linejs/client/features/liff.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "@std/assert";
+import { flex, image, sticker, text } from "./liff.ts";
+
+Deno.test("liff.text — plain", () => {
+	assertEquals(text("hi"), { type: "text", text: "hi" });
+});
+
+Deno.test("liff.text — with sentBy", () => {
+	const m = text("hi", {
+		label: "Bot",
+		iconUrl: "https://example.test/icon.png",
+		linkUrl: "https://example.test",
+	});
+	assertEquals(m, {
+		type: "text",
+		text: "hi",
+		sentBy: {
+			label: "Bot",
+			iconUrl: "https://example.test/icon.png",
+			linkUrl: "https://example.test",
+		},
+	});
+});
+
+Deno.test("liff.sticker", () => {
+	assertEquals(sticker("11537", "52002734"), {
+		type: "sticker",
+		packageId: "11537",
+		stickerId: "52002734",
+	});
+});
+
+Deno.test("liff.image — preview defaults to original", () => {
+	const m = image("https://example.test/a.jpg");
+	assertEquals(m, {
+		type: "image",
+		originalContentUrl: "https://example.test/a.jpg",
+		previewImageUrl: "https://example.test/a.jpg",
+	});
+});
+
+Deno.test("liff.image — explicit preview", () => {
+	const m = image("https://example.test/orig.jpg", "https://example.test/thumb.jpg");
+	assertEquals(m.previewImageUrl, "https://example.test/thumb.jpg");
+});
+
+Deno.test("liff.flex — passes contents through", () => {
+	const contents = { type: "bubble", body: { type: "box", layout: "vertical" } };
+	const m = flex("alt", contents);
+	assertEquals(m.type, "flex");
+	assertEquals(m.altText, "alt");
+	assertEquals(m.contents, contents);
+});

--- a/packages/linejs/client/features/liff.ts
+++ b/packages/linejs/client/features/liff.ts
@@ -1,0 +1,164 @@
+/**
+ * High-level LIFF helpers built on top of the hand-written
+ * {@link "../../base/service/liff/mod.ts" | LiffService} RPC layer.
+ *
+ * The base \`LiffService\` already covers the wire surface (issueLiffView /
+ * getLiffToken / sendLiff / sub-LIFF / consent flow); this module is the
+ * ergonomic adapter for it on \`Client\`.  Two motivations:
+ *
+ * 1. Save callers from having to know the LiffService's token-cache and
+ *    consent retry mechanics.  \`client.liff.shareMessages(chatMid, [...])\`
+ *    does what 90% of bots want with one call.
+ * 2. Provide typed builders for the most common LINE Messaging-API
+ *    message objects (text, sticker, image) so callers don't have to
+ *    hand-roll the JSON.
+ */
+import type { Client } from "../mod.ts";
+
+/** A LINE Messaging-API message payload, in the JSON shape accepted by
+ *  the LIFF share endpoint (`/message/v3/share`).  The full schema is
+ *  documented at https://developers.line.biz/en/reference/messaging-api/.
+ *  This type is intentionally loose because LINE keeps extending it. */
+export type LiffMessage =
+	| LiffTextMessage
+	| LiffStickerMessage
+	| LiffImageMessage
+	| LiffFlexMessage
+	| LiffTemplateMessage
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	| Record<string, any>;
+
+export interface LiffTextMessage {
+	type: "text";
+	text: string;
+	sentBy?: { label: string; iconUrl: string; linkUrl?: string };
+}
+export interface LiffStickerMessage {
+	type: "sticker";
+	packageId: string;
+	stickerId: string;
+}
+export interface LiffImageMessage {
+	type: "image";
+	originalContentUrl: string;
+	previewImageUrl: string;
+}
+export interface LiffFlexMessage {
+	type: "flex";
+	altText: string;
+	contents: Record<string, unknown>;
+}
+export interface LiffTemplateMessage {
+	type: "template";
+	altText: string;
+	template: Record<string, unknown>;
+}
+
+/** Build a plain-text LIFF message.  Optional `sentBy` adds the
+ *  "shared by X" badge LIFF apps can attach. */
+export function text(
+	body: string,
+	sentBy?: LiffTextMessage["sentBy"],
+): LiffTextMessage {
+	return sentBy ? { type: "text", text: body, sentBy } : { type: "text", text: body };
+}
+
+/** Build a sticker LIFF message. */
+export function sticker(packageId: string, stickerId: string): LiffStickerMessage {
+	return { type: "sticker", packageId, stickerId };
+}
+
+/** Build an image LIFF message.  `previewImageUrl` defaults to the
+ *  original-content URL when not supplied. */
+export function image(
+	originalContentUrl: string,
+	previewImageUrl: string = originalContentUrl,
+): LiffImageMessage {
+	return { type: "image", originalContentUrl, previewImageUrl };
+}
+
+/** Build a Flex Message.  `contents` must follow LINE's Flex JSON. */
+export function flex(
+	altText: string,
+	contents: Record<string, unknown>,
+): LiffFlexMessage {
+	return { type: "flex", altText, contents };
+}
+
+export interface LiffClient {
+	/** The bot's default LIFF id, used when callers don't pass one. */
+	readonly defaultLiffId: string;
+	/** Override the default LIFF id (does not persist across reloads). */
+	setDefaultLiffId(liffId: string): void;
+	/** Mints a LIFF access token for a given chat + LIFF app id.
+	 *  Handles consent retry under the hood. */
+	getToken(opts: { chatMid?: string; liffId?: string; lang?: string }): Promise<string>;
+	/** Sends one or more LIFF messages to a chat via the LIFF share
+	 *  endpoint.  Returns the raw server response so callers can read
+	 *  `sentMessages[]` if they need the assigned message ids. */
+	shareMessages(
+		to: string,
+		messages: LiffMessage[],
+		opts?: { liffId?: string; forceIssue?: boolean },
+	): Promise<unknown>;
+	/** Single-message convenience.  Equivalent to
+	 *  `shareMessages(to, [message], opts)`. */
+	shareMessage(
+		to: string,
+		message: LiffMessage,
+		opts?: { liffId?: string; forceIssue?: boolean },
+	): Promise<unknown>;
+	/** Lower-level access to the LiffService for callers who need its
+	 *  full surface (sub-LIFF, getLiffViewWithoutUserContext, etc.). */
+	readonly service: import("../../base/service/liff/mod.ts").LiffService;
+}
+
+class ClientLiff implements LiffClient {
+	#client: Client;
+	#liffId: string;
+	constructor(client: Client) {
+		this.#client = client;
+		this.#liffId = client.base.liff.liffId;
+	}
+	get defaultLiffId(): string {
+		return this.#liffId;
+	}
+	setDefaultLiffId(liffId: string): void {
+		this.#liffId = liffId;
+		this.#client.base.liff.liffId = liffId;
+	}
+	get service() {
+		return this.#client.base.liff;
+	}
+	async getToken(opts: { chatMid?: string; liffId?: string; lang?: string }) {
+		return await this.#client.base.liff.getLiffToken({
+			chatMid: opts.chatMid,
+			liffId: opts.liffId ?? this.#liffId,
+			lang: opts.lang,
+		});
+	}
+	async shareMessages(
+		to: string,
+		messages: LiffMessage[],
+		opts: { liffId?: string; forceIssue?: boolean } = {},
+	) {
+		return await this.#client.base.liff.sendLiff({
+			to,
+			messages: messages as never,
+			forceIssue: opts.forceIssue,
+		});
+	}
+	shareMessage(
+		to: string,
+		message: LiffMessage,
+		opts?: { liffId?: string; forceIssue?: boolean },
+	) {
+		return this.shareMessages(to, [message], opts);
+	}
+}
+
+/** Construct the `Client.liff` adapter.  Not user-facing — the Client
+ *  class instantiates this lazily. */
+export function createLiffClient(client: Client): LiffClient {
+	return new ClientLiff(client);
+}

--- a/skills/linejs/SKILL.md
+++ b/skills/linejs/SKILL.md
@@ -66,6 +66,7 @@ https://github.com/evex-dev/linejs
 | change profile attributes | `client.updateMyProfile({...})` / see `packages/linejs/client/features/profile.ts` |
 | rename / favourite / mute friends | `User.rename()` / `User.setFavorite()` etc. — see `packages/linejs/client/features/user/mod.ts` |
 | chat BGM | `Chat.getBgm()` / `Chat.setBgm()` |
+| LIFF share / token | `client.liff.shareMessages(chatMid, [...])` and `client.liff.getToken({ liffId, chatMid })` — see `packages/linejs/client/features/liff.ts` for message builders (`text` / `sticker` / `image` / `flex`).  Lower-level surface at `client.liff.service` / `BaseClient.liff`. |
 | calendar events on a contact | `User.fetchCalendarEvents()` — note: server-gated on some client device types (DESKTOPWIN currently lacks it) |
 | upload profile picture / cover | `client.uploadMyProfileImage(blob)` / `client.uploadMyProfileBackground(blob)` |
 | **Agent I** (LINE's chat-tab AI search) | `@evex/linejs-agent` — wraps Yahoo's search-agent SSE backend that LINE Android opens in a WebView. Requires Yahoo session cookies; LINE does not mint them. |


### PR DESCRIPTION
## Description

High-level \`Client.liff\` accessor on top of the existing \`LiffService\` so bot code doesn't have to know about token-cache / consent-retry mechanics for the 90% case.

## Surface

\`client.liff\` (\`LiffClient\` interface):
- \`getToken({ chatMid?, liffId?, lang? })\` — minted via cached \`getLiffToken\` with consent retry under the hood
- \`shareMessages(to, messages, { liffId?, forceIssue? })\` — POSTs to the LIFF share endpoint.  Single-message convenience: \`shareMessage(to, message)\`
- \`defaultLiffId\` / \`setDefaultLiffId(id)\` — override the bot's default LIFF id without touching \`BaseClient.liff\` directly
- \`service\` — escape hatch to the full \`LiffService\` for sub-LIFF, no-user-context views, etc.

## Message builders

Re-exported from \`features/liff.ts\`:
- \`text(body, sentBy?)\` — plain text, optional \"shared by X\" badge
- \`sticker(packageId, stickerId)\`
- \`image(originalUrl, previewUrl?)\` — preview defaults to original
- \`flex(altText, contents)\` — Flex Message JSON

## Tests

\`packages/linejs/client/features/liff.test.ts\` — 6 unit tests.  Total workspace: **19/19 passing**.

## Skill

\`skills/linejs/SKILL.md\` updated with a \"LIFF share / token\" row.

## Why this is v2.7.3

Issue #150 / #151 (Note / VOOM) need Frida wire-traces and aren't shippable today; #42 / #45 (Agent I auth + chat-embedded path) ditto.  This LIFF improvement is the one task in the v2.7.3 milestone that's deno-pure and testable offline, so it ships now.

## Checklist

- [x] 6 new tests
- [x] 19/19 tests pass workspace-wide
- [x] deno check clean
- [x] jsdoc on public surface
- [x] skill SKILL.md updated