### PR TITLE
feat(client): VOOM/Note REST gateway helpers + channel-id constants (v2.7.5)

### DIFF
--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -15,6 +15,10 @@ import {
 } from "./features/profile.ts";
 import { createLiffClient, type LiffClient } from "./features/liff.ts";
 export * as liff from "./features/liff.ts";
+export * as voom from "./features/voom.ts";
+import { VoomChannelId, voomRest, type VoomRestOptions, type VoomRestResponse } from "./features/voom.ts";
+export { VoomChannelId };
+export type { VoomRestOptions, VoomRestResponse };
 export { Chat, Square, SquareChat, SquareMessage, TalkMessage, User };
 export { ProfileAttribute } from "./features/profile.ts";
 export type { MyProfileUpdate } from "./features/profile.ts";
@@ -59,6 +63,14 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 	get liff(): LiffClient {
 		if (!this.#liff) this.#liff = createLiffClient(this);
 		return this.#liff;
+	}
+
+	/**
+	 * Low-level VOOM REST call.  See {@link "./features/voom.ts"} for
+	 * docs + channel-token caveats (#151 tracks the auth investigation).
+	 */
+	voomRest<T = unknown>(opts: VoomRestOptions): Promise<VoomRestResponse<T>> {
+		return voomRest(this, opts);
 	}
 
 	/**

--- a/packages/linejs/client/features/voom.test.ts
+++ b/packages/linejs/client/features/voom.test.ts
@@ -1,0 +1,10 @@
+import { assertEquals } from "@std/assert";
+import { VoomChannelId } from "./voom.ts";
+
+Deno.test("VoomChannelId — TIMELINE id matches LINE Android smali", () => {
+	// From decompiled/base/smali/smali/t98/a$b.smali (release id).
+	assertEquals(VoomChannelId.TIMELINE, "1341209950");
+	assertEquals(VoomChannelId.HOME, "1341209850");
+	assertEquals(VoomChannelId.NOTE, "1655599932");
+	assertEquals(VoomChannelId.SQUARE_NOTE, "1657618623");
+});

--- a/packages/linejs/client/features/voom.ts
+++ b/packages/linejs/client/features/voom.ts
@@ -1,0 +1,90 @@
+/**
+ * VOOM (timeline / myhome) REST helpers.
+ *
+ * VOOM lives on a separate REST gateway under
+ * `https://gw.line.naver.jp/mh/api/v{34,40,52,57}/...` rather than the
+ * Thrift binary protocol used by Talk/Square.  Confirmed dynamically
+ * against LINE 26.6.2 — every documented path returns JSON envelopes
+ * of the form `{ code, message, result }`.
+ *
+ * **Auth status (provisional, see evex-dev/linejs#151):** the gateway
+ * rejects the raw `X-Line-Access` primaryToken with `code: 401
+ * "Renewing user verification..."`.  It expects a channel-scoped token
+ * for the TIMELINE channel (id `1341209950`), which on DESKTOPWIN
+ * cannot be minted via `Channel.issueChannelToken` — that returns
+ * `ILLEGAL_ARGUMENT: invalid channelId`.  ANDROID-typed clients may
+ * succeed; this helper exposes the wire shape so callers who *can*
+ * mint the right token can drive the gateway.
+ *
+ * Source of truth:
+ *   `decompiled/base/smali/smali/t98/a$b.smali`  — channel id enum
+ *   gateway base path family confirmed by live HTTP probing.
+ */
+import type { Client } from "../mod.ts";
+
+/** Channel-id constants for LINE's MH-family services. */
+export const VoomChannelId = {
+	TIMELINE: "1341209950",
+	HOME: "1341209850",
+	HOME26: "2007835442",
+	NOTE: "1655599932",
+	SQUARE_NOTE: "1657618623",
+	ALBUM: "1375220249",
+} as const;
+
+export interface VoomRestOptions {
+	/** Path under `/mh/api/`, leading slash included. */
+	path: string;
+	method?: "GET" | "POST" | "PUT" | "DELETE";
+	body?: unknown;
+	/** Override the channel token used in `X-Line-ChannelToken`.  When
+	 *  unset, falls back to the client's primaryToken in `X-Line-Access`
+	 *  (which currently 401s on the MH gateway — see #151). */
+	channelToken?: string;
+	/** Additional headers to send. */
+	extraHeaders?: Record<string, string>;
+	/** Override the gateway hostname. */
+	host?: string;
+}
+
+export interface VoomRestResponse<T = unknown> {
+	code: number;
+	message?: string;
+	result: T | null;
+}
+
+/**
+ * Low-level VOOM REST call.  Hands you the JSON envelope verbatim so
+ * you can iterate against the gateway while we sort out the auth
+ * story (#151).
+ */
+export async function voomRest<T = unknown>(
+	client: Client,
+	opts: VoomRestOptions,
+): Promise<VoomRestResponse<T>> {
+	const host = opts.host ?? "gw.line.naver.jp";
+	const method = opts.method ?? "GET";
+	const url = `https://${host}${
+		opts.path.startsWith("/") ? opts.path : "/" + opts.path
+	}`;
+
+	const headers: Record<string, string> = {
+		accept: "application/json",
+		"x-line-application": client.base.request.systemType,
+		"user-agent": client.base.request.userAgent,
+		"x-line-access": client.authToken,
+		...(opts.channelToken
+			? { "X-Line-ChannelToken": opts.channelToken }
+			: {}),
+		...(opts.extraHeaders ?? {}),
+	};
+	if (opts.body !== undefined) headers["content-type"] = "application/json";
+
+	const res = await client.base.fetch(url, {
+		method,
+		headers,
+		body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+	});
+	const json = await res.json() as VoomRestResponse<T>;
+	return json;
+}

--- a/skills/linejs/SKILL.md
+++ b/skills/linejs/SKILL.md
@@ -67,6 +67,7 @@ https://github.com/evex-dev/linejs
 | rename / favourite / mute friends | `User.rename()` / `User.setFavorite()` etc. — see `packages/linejs/client/features/user/mod.ts` |
 | chat BGM | `Chat.getBgm()` / `Chat.setBgm()` |
 | LIFF share / token | `client.liff.shareMessages(chatMid, [...])` and `client.liff.getToken({ liffId, chatMid })` — see `packages/linejs/client/features/liff.ts` for message builders (`text` / `sticker` / `image` / `flex`).  Lower-level surface at `client.liff.service` / `BaseClient.liff`. |
+| VOOM / timeline / Note REST | `client.voomRest({ path: "/v40/post/list.json" })` — low-level wrapper around the `gw.line.naver.jp/mh/api/v{34,40,52,57}/...` gateway.  Channel IDs from LINE Android smali in `VoomChannelId.{TIMELINE, HOME, NOTE, SQUARE_NOTE, ALBUM}`.  Auth caveat: server currently returns `code:401 "Renewing user verification…"` with plain X-Line-Access; needs a channel-scoped token — see #151. |
 | calendar events on a contact | `User.fetchCalendarEvents()` — note: server-gated on some client device types (DESKTOPWIN currently lacks it) |
 | approve a PIN login on this device | `client.base.loginProcess.respondE2EELoginRequest({ verifier, publicKey, encryptedKeyChain, hashKeyChain, errorCode? })` — primary-side counterpart to `confirmE2EELogin`. Call when this client receives a PIN-login notification from another device the user wants to admit. |
 | upload profile picture / cover | `client.uploadMyProfileImage(blob)` / `client.uploadMyProfileBackground(blob)` |


### PR DESCRIPTION
## Description

Dynamic-analysis ship from the v2.7.5 cycle: VOOM, timeline, and Note features in LINE Android 26.6.2 don't go through Thrift — they hit a REST JSON gateway under \`https://gw.line.naver.jp/mh/api/v{34,40,52,57}/...\`.  Confirmed live by probing with a captured primaryToken (the gateway returns the LINE myhome envelope \`{code,message,result}\`).

## What ships

- **\`client.voomRest({ path, method?, body?, channelToken?, extraHeaders?, host? })\`** — low-level wrapper around the MH gateway.  Returns the envelope verbatim, including the \`code:401 \"Renewing user verification...\"\` the gateway emits when the auth header isn't channel-scoped.
- **\`VoomChannelId\`** — release-channel ids for the MH-family services, recovered from LINE Android smali at \`t98.a\$b\`:
  - \`TIMELINE\` = \`\"1341209950\"\`
  - \`HOME\`     = \`\"1341209850\"\`
  - \`HOME26\`   = \`\"2007835442\"\`
  - \`NOTE\`     = \`\"1655599932\"\`
  - \`SQUARE_NOTE\` = \`\"1657618623\"\`
  - \`ALBUM\`    = \`\"1375220249\"\`

## Auth caveat (#151)

The MH gateway expects a channel-scoped token for the relevant channel id, **not** the raw X-Line-Access primaryToken.  \`Channel.issueChannelToken(\"1341209950\")\` from a DESKTOPWIN client currently returns \`ILLEGAL_ARGUMENT: invalid channelId\` — the channel-token issuance appears device-type-gated.  Tracking the remaining auth investigation in #151.

Even with the auth gap unresolved, the URL-builder + channel-id constants unblock callers who can mint the token elsewhere (e.g. via an ANDROID session) — they can hand it in via \`channelToken:\` and drive the gateway directly.

## Tests

1 new test verifying the channel-id constants match the smali values.  Total workspace: **22/22 pass**.

## Skill

\`skills/linejs/SKILL.md\` gains a row pointing agents at \`client.voomRest\` + \`VoomChannelId\`.

## Issues

- #151 (VOOM) — primary auth investigation
- #150 (Note) — shares the same auth gating; same gateway family

Both updated with the dynamic findings.