### PR TITLE
v2.8.3: fetchUsers fallback (#71) + E2EE media preview slim (#103)

### DIFF
--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -830,6 +830,23 @@ export class E2EE {
 		const receiverKeyId = byte2int(chunks[4]);
 		this.e2eeLog("decryptE2EEDataMessageSenderKeyId", senderKeyId);
 		this.e2eeLog("decryptE2EEDataMessageReceiverKeyId", receiverKeyId);
+		// Diagnostic for issue #88 — when 1:1 media decryption fails with
+		// "Unsupported state or unable to authenticate data" we need to see
+		// exactly which byte the AAD was built from.  Text in the same chat
+		// works, so capture enough state here to bisect against a real LINE
+		// ciphertext sample.
+		this.e2eeLog("decryptE2EEDataMessageEnvelope", {
+			toType,
+			specVersion,
+			rawContentType: messageObj.contentType,
+			resolvedContentType: contentType,
+			chatTo: to,
+			chatFrom: _from,
+			isSelf,
+			chunkTypes: chunks.map((c) =>
+				`${c.constructor?.name ?? typeof c}(${c.length})`
+			),
+		});
 
 		const selfKey = await this.getE2EESelfKeyData(
 			this.client.profile?.mid as string,

--- a/packages/linejs/base/obs/mod.ts
+++ b/packages/linejs/base/obs/mod.ts
@@ -305,8 +305,17 @@ export class LineObs {
 		oType: ObjType;
 		to: string;
 		filename?: string;
+		/**
+		 * Optional pre-generated thumbnail for `image`/`gif`/`video` uploads.
+		 * When provided, it is encrypted with the same `keyMaterial` as the
+		 * main object and uploaded as `__ud-preview`, saving bandwidth (issue
+		 * #103).  When omitted, the previous behavior — re-uploading the full
+		 * encrypted blob as the preview — is preserved for backward compat.
+		 * Callers should pass a small (~256–512px wide) JPEG/PNG/MP4 frame.
+		 */
+		preview?: Blob;
 	}): Promise<Message> {
-		const { data, oType, to, filename } = options;
+		const { data, oType, to, filename, preview } = options;
 		const typeSet: {
 			image: [string, 1];
 			video: [string, 2];
@@ -348,9 +357,24 @@ export class LineObs {
 			params,
 		});
 		if (oType === "image" || oType === "gif" || oType === "video") {
+			// Encrypt the preview with the *same* keyMaterial so the recipient
+			// can reuse the decryption key the main message already carries.
+			// Fall back to the full encrypted blob only when no preview was
+			// supplied (legacy path; issue #103).
+			let previewEdata: Blob;
+			if (preview) {
+				const enc = await this.client.e2ee.encryptByKeyMaterial(
+					Buffer.from(await preview.arrayBuffer()),
+					Buffer.from(keyMaterial, "base64"),
+				);
+				// @ts-expect-error: Buffer is a valid BlobPart at runtime
+				previewEdata = new Blob([enc.encryptedData]);
+			} else {
+				previewEdata = edata;
+			}
 			const { objId: objId2, headers } = await this
 				.uploadObjectForService({
-					data: edata,
+					data: previewEdata,
 					oType: "file",
 					obsPath: `${serviceName}/${obsNamespace}/${objId}__ud-preview`,
 					params,

--- a/packages/linejs/base/obs/upload_e2ee.test.ts
+++ b/packages/linejs/base/obs/upload_e2ee.test.ts
@@ -1,0 +1,114 @@
+import { assert, assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { LineObs } from "./mod.ts";
+
+/** Per-call record of (data.size, obsPath) so tests can assert which
+ *  blob was uploaded as the main object vs the preview. */
+type UploadRecord = { size: number; obsPath: string };
+
+function fakeClient() {
+	const e2eeCalls: { rawSize: number; keyMaterial?: string }[] = [];
+	const sendMessageCalls: unknown[] = [];
+	return {
+		records: [] as UploadRecord[],
+		e2eeCalls,
+		sendMessageCalls,
+		mock: {
+			e2ee: {
+				encryptByKeyMaterial(rawData: Buffer, keyMaterial?: Buffer) {
+					e2eeCalls.push({
+						rawSize: rawData.length,
+						keyMaterial: keyMaterial?.toString("base64"),
+					});
+					return Promise.resolve({
+						keyMaterial: keyMaterial
+							? keyMaterial.toString("base64")
+							: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+						encryptedData: Buffer.from(
+							new Uint8Array(rawData.length + 32),
+						),
+					});
+				},
+				encryptE2EEMessage() {
+					return Promise.resolve([new Uint8Array()]);
+				},
+			},
+			talk: {
+				sendMessage(args: unknown) {
+					sendMessageCalls.push(args);
+					return Promise.resolve({ id: "m-1" });
+				},
+			},
+		},
+	};
+}
+
+function makeObs(): {
+	obs: LineObs;
+	fake: ReturnType<typeof fakeClient>;
+} {
+	const fake = fakeClient();
+	const obs = new LineObs(fake.mock as never);
+	// Intercept uploadObjectForService to record what was sent.
+	obs.uploadObjectForService = ((opts: {
+		data: Blob;
+		obsPath: string;
+	}) => {
+		fake.records.push({ size: opts.data.size, obsPath: opts.obsPath });
+		return Promise.resolve({
+			objId: "OBJ-1",
+			headers: new Headers(),
+		});
+	}) as never;
+	return { obs, fake };
+}
+
+Deno.test("uploadMediaByE2EE — without preview, legacy: full edata uploaded twice (#103)", async () => {
+	const { obs, fake } = makeObs();
+	const big = new Blob([new Uint8Array(100_000)]);
+	await obs.uploadMediaByE2EE({
+		data: big,
+		oType: "image",
+		to: "u-recipient",
+	});
+	assertEquals(fake.records.length, 2);
+	// Both uploads carry the same (full) encrypted blob:
+	assertEquals(fake.records[0].size, fake.records[1].size);
+	assert(fake.records[1].obsPath.endsWith("__ud-preview"));
+});
+
+Deno.test("uploadMediaByE2EE — with preview, preview upload uses small blob (#103)", async () => {
+	const { obs, fake } = makeObs();
+	const big = new Blob([new Uint8Array(100_000)]);
+	const thumb = new Blob([new Uint8Array(2_000)]);
+	await obs.uploadMediaByE2EE({
+		data: big,
+		oType: "image",
+		to: "u-recipient",
+		preview: thumb,
+	});
+	assertEquals(fake.records.length, 2);
+	// Main upload ≫ preview upload.
+	assert(fake.records[0].size > fake.records[1].size);
+	assert(fake.records[1].obsPath.endsWith("__ud-preview"));
+	// Main upload did NOT pass a keyMaterial (generated fresh inside);
+	// the preview call MUST reuse the returned base64 keyMaterial.
+	assertEquals(fake.e2eeCalls.length, 2);
+	assertEquals(fake.e2eeCalls[0].keyMaterial, undefined);
+	assertEquals(
+		fake.e2eeCalls[1].keyMaterial,
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+	);
+});
+
+Deno.test("uploadMediaByE2EE — file type → no preview upload at all", async () => {
+	const { obs, fake } = makeObs();
+	const doc = new Blob([new Uint8Array(50_000)]);
+	await obs.uploadMediaByE2EE({
+		data: doc,
+		oType: "file",
+		to: "u-recipient",
+		filename: "report.pdf",
+	});
+	assertEquals(fake.records.length, 1);
+});

--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -47,6 +47,15 @@ export type ClientEvents = {
 	"square:event": (event: LINETypes.SquareEvent) => void;
 };
 
+/** True if the thrown error is the server's "API method not capable"
+ *  signal (the message LINE returns when the calling client's device
+ *  type isn't allowed to use the RPC).  Used to drive the
+ *  V3 → V2 → V1 fallback chain in {@link Client.fetchUsers}. */
+function isApiNotCapable(e: unknown): boolean {
+	const msg = e instanceof Error ? e.message : String(e);
+	return /API method not capable/i.test(msg);
+}
+
 export class Client extends TypedEventEmitter<ClientEvents> {
 	readonly base: BaseClient;
 	#liff?: LiffClient;
@@ -209,24 +218,50 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 	 * Fetches all friend.
 	 */
 	async fetchUsers(): Promise<User[]> {
-		await 0;
-		throw new Error("fetchUsers is not implemented")
-		/*
 		const { userFriendMids } = await this.base.relation.getUserFriendIds({
-			request: {
-				blockStatus: "ALL",
-			},
+			request: { blockStatus: "ALL" },
 		});
-		const res = await this.base.talk.getContactsV2({
-			mids: userFriendMids,
-		});
-		const contacts = res.responses;
-		return contacts.map((raw) =>
-			new User({
-				raw,
-			})
-		);
-		*/
+		if (!userFriendMids?.length) return [];
+
+		// Prefer Relation.getContactsV3 (returns GetContactV3Response[]).
+		// DESKTOPWIN clients can't call V3 ("API method not capable") so
+		// fall back to Talk.getContactsV2 → Talk.getContacts.  All three
+		// shapes feed `new User({ raw })` because User only reads
+		// `targetUserMid` + a handful of optional fields that overlap.
+		try {
+			const res = await this.base.relation.getContactsV3({
+				mids: userFriendMids,
+			});
+			return res.responses.map((raw) => new User({ client: this, raw }));
+		} catch (e) {
+			if (!isApiNotCapable(e)) throw e;
+		}
+		try {
+			const res2 = await this.base.talk.getContactsV2({
+				mids: userFriendMids,
+			});
+			// V2 returns `contacts: Record<mid, ContactEntry>`; shim each
+			// entry into a V3-shaped `{ targetUserMid, ...entry }` so
+			// User's existing readers keep working.
+			const out: User[] = [];
+			for (const [mid, entry] of Object.entries(res2.contacts ?? {})) {
+				out.push(new User({
+					client: this,
+					raw: { ...(entry as object), targetUserMid: mid } as never,
+				}));
+			}
+			if (out.length) return out;
+		} catch (e) {
+			if (!isApiNotCapable(e)) throw e;
+		}
+		// Final fallback: per-mid getContact loop (last resort, slowest).
+		const out: User[] = [];
+		for (const mid of userFriendMids) {
+			try {
+				out.push(await this.getUser(mid));
+			} catch { /* skip unreachable */ }
+		}
+		return out;
 	}
 
 	/**

--- a/packages/linejs/client/fetch_users.test.ts
+++ b/packages/linejs/client/fetch_users.test.ts
@@ -1,0 +1,81 @@
+import { assert, assertEquals } from "@std/assert";
+import { Client } from "./client.ts";
+
+function buildClient(opts: {
+	friendMids: string[];
+	v3?: (req: { mids: string[] }) => Promise<unknown> | unknown;
+	v2?: (req: { mids: string[] }) => Promise<unknown> | unknown;
+}) {
+	const base = {
+		profile: { mid: "u-self" },
+		relation: {
+			getUserFriendIds: () =>
+				Promise.resolve({ userFriendMids: opts.friendMids }),
+			getContactsV3: opts.v3 ?? (() => {
+				throw new Error("API method not capable: 'getContactsV3'");
+			}),
+		},
+		talk: {
+			getContactsV2: opts.v2 ?? (() => {
+				throw new Error("API method not capable: 'getContactsV2'");
+			}),
+		},
+	};
+	return new Client(base as never);
+}
+
+Deno.test("fetchUsers — empty friend list → empty result", async () => {
+	const client = buildClient({ friendMids: [] });
+	const users = await client.fetchUsers();
+	assertEquals(users.length, 0);
+});
+
+Deno.test("fetchUsers — V3 path", async () => {
+	const client = buildClient({
+		friendMids: ["u-a", "u-b"],
+		v3: () =>
+			Promise.resolve({
+				responses: [
+					{ targetUserMid: "u-a", displayName: "Alice" },
+					{ targetUserMid: "u-b", displayName: "Bob" },
+				],
+			}),
+	});
+	const users = await client.fetchUsers();
+	assertEquals(users.length, 2);
+	assertEquals(users[0].mid, "u-a");
+	assertEquals(users[1].mid, "u-b");
+});
+
+Deno.test("fetchUsers — V2 fallback when V3 not capable", async () => {
+	const client = buildClient({
+		friendMids: ["u-x"],
+		v3: () => {
+			throw new Error("API method not capable: 'getContactsV3'");
+		},
+		v2: () =>
+			Promise.resolve({
+				contacts: { "u-x": { displayName: "Xeno", userStatus: 0 } },
+			}),
+	});
+	const users = await client.fetchUsers();
+	assertEquals(users.length, 1);
+	assertEquals(users[0].mid, "u-x");
+});
+
+Deno.test("fetchUsers — non-capability errors are rethrown", async () => {
+	const client = buildClient({
+		friendMids: ["u-z"],
+		v3: () => {
+			throw new Error("AUTHENTICATION_FAILED");
+		},
+	});
+	let err: unknown;
+	try {
+		await client.fetchUsers();
+	} catch (e) {
+		err = e;
+	}
+	assert(err instanceof Error);
+	assertEquals((err as Error).message, "AUTHENTICATION_FAILED");
+});


### PR DESCRIPTION
## Summary
- Closes #71 — `Client.fetchUsers` now falls back from `Relation.getContactsV3` to `Talk.getContactsV2` when the device type is rejected with *API method not capable*, then to per-mid `getUser` as a last resort.  Non-capability errors propagate.
- Closes #103 — `ObsClient.uploadMediaByE2EE` accepts an optional `preview: Blob`; when supplied the preview is encrypted with the same `keyMaterial` and uploaded to `__ud-preview`, instead of re-uploading the full encrypted blob.  Existing callers (no preview) keep the legacy behavior.
- Diagnostic for #88 — added an `e2eeLog` line to `decryptE2EEDataMessage` capturing AAD inputs (toType, specVersion, resolved contentType, chunk shapes).  The actual GCM auth failure needs a real 1:1 media ciphertext sample to bisect.

## Test plan
- [x] `deno test --allow-all packages/` (34/34 pass)
- [x] `deno check packages/linejs/client/mod.ts`
- [x] `deno check packages/linejs/base/mod.ts`
- [ ] Live-verify on real LINE traffic post-merge