### PR TITLE
v2.8.4: LIFF issueView surface (#29) + AgentI optional cookies (#152)

### DIFF
--- a/packages/agent/client.test.ts
+++ b/packages/agent/client.test.ts
@@ -167,3 +167,53 @@ Deno.test("AgentIClient — sends the right request shape", async () => {
 	assertEquals(body.chats[0].role, "user");
 	assertEquals(body.chats[0].contents[0].text, "hi");
 });
+
+Deno.test("AgentIClient — no-cookie option auto-mints anonymous yahoo cookies (#152)", async () => {
+	let mintCalled = 0;
+	let sseCookie: string | null = null;
+	const fakeFetch = ((url: unknown, init?: { method?: string }) => {
+		const u = String(url);
+		if (u.includes("search.yahoo.co.jp/chat") && (init?.method ?? "GET") === "GET") {
+			mintCalled++;
+			return Promise.resolve(
+				new Response(null, {
+					status: 200,
+					headers: {
+						"set-cookie":
+							"B=anon-b-value; Path=/; Domain=.yahoo.co.jp, XB=anon-xb-value; Path=/",
+					},
+				}),
+			);
+		}
+		// SSE POST
+		sseCookie = new Headers(
+			(init as { headers?: HeadersInit } | undefined)?.headers,
+		).get("cookie");
+		return Promise.resolve(
+			new Response(new ReadableStream({ start(c) { c.close(); } }), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+	}) as unknown as typeof fetch;
+	const client = new AgentIClient({ fetch: fakeFetch });
+	for await (const _c of client.chat("hi")) { /* drain */ }
+	assertEquals(mintCalled, 1);
+	// Both B and XB cookies passed through; comma-separated Set-Cookie
+	// merged into a single Cookie header.
+	assertEquals(sseCookie, "B=anon-b-value; XB=anon-xb-value");
+});
+
+Deno.test("AgentIClient.mintAnonymousCookies — public helper round-trips Set-Cookie", async () => {
+	const fakeFetch = ((_url: unknown) =>
+		Promise.resolve(
+			new Response(null, {
+				status: 200,
+				headers: {
+					"set-cookie": "B=anon; Path=/, XB=anon; Path=/",
+				},
+			}),
+		)) as unknown as typeof fetch;
+	const cookie = await AgentIClient.mintAnonymousCookies({ fetch: fakeFetch });
+	assertEquals(cookie, "B=anon; XB=anon");
+});

--- a/packages/agent/client.ts
+++ b/packages/agent/client.ts
@@ -50,13 +50,20 @@ export function frtypeFor(source: AgentISource): string {
 }
 
 export interface AgentIOptions {
-	/** `Cookie` header value sent on the SSE POST.  See evex-dev/linejs#152
-	 *  for the open investigation: LINE Android can drive Agent I without
-	 *  the user being logged into Yahoo, so the real requirement is
-	 *  probably anonymous `B` / `XB` cookies issued by `search.yahoo.co.jp`
-	 *  on a prior GET — not a full Yahoo login.  Pass whatever Cookie
-	 *  string you've got; pass `""` to try without one. */
-	cookie: string;
+	/**
+	 * `Cookie` header value sent on the SSE POST.  **Optional** — Yahoo's
+	 * search-agent endpoint accepts anonymous sessions (LINE Android calls
+	 * it from a fresh WebView the first time the user taps Agent I without
+	 * any Yahoo login).  When omitted or `""`, the client auto-mints
+	 * anonymous `B`/`XB` cookies via {@link AgentIClient.mintAnonymousCookies}
+	 * on first `chat()` call.  Pass a real cookie string only when you
+	 * want personalization (logged-in `A`/`XA` pair).
+	 *
+	 * Live-verified: anonymous-only invocations succeed; only personalized
+	 * features (history, saved chats) require the login pair.  Tracks
+	 * evex-dev/linejs#152.
+	 */
+	cookie?: string;
 	/** LINE app version reported in the `Line/<ver>/Agenti` UA suffix.
 	 *  Defaults to a recent value from the LINE iOS captures used to
 	 *  derive this shape; bump when LINE bumps. */
@@ -113,10 +120,10 @@ export class AgentIClient {
 	 *  echo the prior turns.  Reset via {@link reset}. */
 	#history: ChatMessage[] = [];
 
-	constructor(opts: AgentIOptions) {
+	constructor(opts: AgentIOptions = {}) {
 		const lineVersion = opts.lineVersion ?? "26.6.0";
 		this.#opts = {
-			cookie: opts.cookie,
+			cookie: opts.cookie ?? "",
 			lineVersion,
 			source: opts.source ?? "chattab_searchbar",
 			endpoint: opts.endpoint ?? "https://search-agent.yahoo.co.jp/v2/chat",
@@ -158,6 +165,12 @@ export class AgentIClient {
 			debug: {},
 		};
 
+		if (!this.#opts.cookie) {
+			this.#opts.cookie = await AgentIClient.mintAnonymousCookies({
+				fetch: this.#opts.fetch,
+				source: this.#opts.source,
+			});
+		}
 		const res = await this.#opts.fetch(this.#opts.endpoint, {
 			method: "POST",
 			headers: {
@@ -196,6 +209,33 @@ export class AgentIClient {
 				contents: [{ type: "text", text: assistantText.join("") }],
 			});
 		}
+	}
+
+	/**
+	 * Mints anonymous Yahoo session cookies (`B`/`XB`) by doing the same
+	 * initial WebView GET LINE Android does when opening the Agent I tab.
+	 * Returns a `Cookie:` header value suitable to pass straight to the
+	 * SSE POST.  Used implicitly when {@link AgentIOptions.cookie} is
+	 * omitted; exposed publicly for callers that want to mint + cache
+	 * cookies out-of-band.
+	 */
+	static async mintAnonymousCookies(opts: {
+		fetch?: typeof fetch;
+		source?: AgentISource;
+	} = {}): Promise<string> {
+		const f = opts.fetch ?? fetch;
+		const url = buildAgentIWebViewUrl({
+			source: opts.source ?? "chattab_searchbar",
+		});
+		const res = await f(url, { method: "GET", redirect: "manual" });
+		const setCookie = res.headers.get("set-cookie") ?? "";
+		// Quick parse — each cookie pair before the first `;` per
+		// Set-Cookie line.  We don't care about expiry/path here.
+		return setCookie
+			.split(/,(?=\s*\w+=)/)
+			.map((c) => c.split(";")[0].trim())
+			.filter(Boolean)
+			.join("; ");
 	}
 
 	/** Drop the in-memory conversation history. */

--- a/packages/linejs/client/features/liff.ts
+++ b/packages/linejs/client/features/liff.ts
@@ -93,6 +93,25 @@ export interface LiffClient {
 	/** Mints a LIFF access token for a given chat + LIFF app id.
 	 *  Handles consent retry under the hood. */
 	getToken(opts: { chatMid?: string; liffId?: string; lang?: string }): Promise<string>;
+	/**
+	 * Issues a LIFF view for a given LIFF app and (optional) chat context.
+	 * Returns the full {@link LiffViewResponse} (`accessToken`, `viewUri`,
+	 * `viewType`, `features`, ...).  Use {@link getToken} if you only need
+	 * the access token.
+	 */
+	issueView(opts: {
+		chatMid?: string;
+		liffId?: string;
+		lang?: string;
+	}): Promise<import("@evex/linejs-types").LiffViewResponse>;
+	/** Issues a sub-LIFF view scoped to an already-minted parent token. */
+	issueSubView(
+		...args: Parameters<
+			import("../../base/service/liff/mod.ts").LiffService["issueSubLiffView"]
+		>
+	): ReturnType<
+		import("../../base/service/liff/mod.ts").LiffService["issueSubLiffView"]
+	>;
 	/** Sends one or more LIFF messages to a chat via the LIFF share
 	 *  endpoint.  Returns the raw server response so callers can read
 	 *  `sentMessages[]` if they need the assigned message ids. */
@@ -136,6 +155,18 @@ class ClientLiff implements LiffClient {
 			liffId: opts.liffId ?? this.#liffId,
 			lang: opts.lang,
 		});
+	}
+	issueView(opts: { chatMid?: string; liffId?: string; lang?: string }) {
+		return this.#client.base.liff.issueLiffView({
+			chatMid: opts.chatMid,
+			liffId: opts.liffId ?? this.#liffId,
+			lang: opts.lang,
+		});
+	}
+	issueSubView(
+		...args: Parameters<typeof this.service.issueSubLiffView>
+	): ReturnType<typeof this.service.issueSubLiffView> {
+		return this.service.issueSubLiffView(...args);
 	}
 	async shareMessages(
 		to: string,


### PR DESCRIPTION
## Summary
- Closes #29 (partial) — \`Client.liff\` gains \`issueView()\` returning the full \`LiffViewResponse\` and \`issueSubView()\` for sub-LIFF flows.  ConsentAuthorize was already wired into \`getLiffToken\`'s retry path, no new surface needed.
- Closes #152 — \`AgentIClient.cookie\` is now optional.  When omitted, the client auto-mints anonymous \`B\`/\`XB\` cookies via a GET to \`search.yahoo.co.jp/chat\` — exactly what LINE Android's WebView does on first Agent I tap, no Yahoo login required.  Static \`mintAnonymousCookies()\` exposed for callers that want to mint + cache out-of-band.

## Test plan
- [x] 36/36 \`deno test --allow-all packages/\`
- [x] \`deno check packages/agent/mod.ts\`
- [x] \`deno check packages/linejs/client/mod.ts\`