### PR TITLE
v2.8.5: fix E2EE 1:1 media decrypt fail (#88)

### DIFF
--- a/packages/linejs/base/e2ee/key_selection.test.ts
+++ b/packages/linejs/base/e2ee/key_selection.test.ts
@@ -1,0 +1,166 @@
+import { assert, assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { E2EE } from "./mod.ts";
+
+/** Builds an E2EE instance with a stub BaseClient that records which
+ *  self-key id was looked up.  We don't try to mock a working GCM
+ *  ciphertext — instead we trap `decryptE2EEMessageV2` and assert on
+ *  the privK / pubK that flowed into it. */
+function makeE2EE(opts: {
+	keysByKeyId: Record<string | number, { privKey: string; pubKey: string }>;
+	latestKey: { privKey: string; pubKey: string; keyId?: number };
+	receiverPubKey: Buffer;
+}) {
+	const lookups: (string | number)[] = [];
+	const fakeBase = {
+		profile: { mid: "u-self" },
+		storage: {
+			get(k: string) {
+				const m = k.match(/^e2eeKeys:(.+)$/);
+				if (!m) return Promise.resolve(null);
+				const id = m[1];
+				if (id === "u-self") {
+					return Promise.resolve(JSON.stringify(opts.latestKey));
+				}
+				lookups.push(id);
+				if (opts.keysByKeyId[id]) {
+					return Promise.resolve(JSON.stringify(opts.keysByKeyId[id]));
+				}
+				return Promise.resolve(null);
+			},
+		},
+		talk: {
+			getE2EEPublicKeys() {
+				return Promise.resolve([]);
+			},
+		},
+		getToType() {
+			return 0;
+		},
+		log() {},
+	};
+	const e2ee = new E2EE(fakeBase as never);
+	// Stub getE2EELocalPublicKey so we don't need a real Curve25519 pubkey
+	(e2ee as unknown as {
+		getE2EELocalPublicKey: unknown;
+	}).getE2EELocalPublicKey = () => Promise.resolve(opts.receiverPubKey);
+
+	// Trap decryptE2EEMessageV2 — we want to verify which privK reached it.
+	const seen: { privK: Buffer | null; pubK: unknown } = {
+		privK: null,
+		pubK: null,
+	};
+	(e2ee as unknown as {
+		decryptE2EEMessageV2: unknown;
+	}).decryptE2EEMessageV2 = (
+		_to: string,
+		_from: string,
+		_chunks: Buffer[],
+		privK: Buffer,
+		pubK: Buffer,
+	) => {
+		seen.privK = privK;
+		seen.pubK = pubK;
+		return { text: "ok-stub", keyMaterial: "00", fileName: "x" };
+	};
+
+	return { e2ee, seen, lookups };
+}
+
+function makeFakeMessage(opts: {
+	senderKeyId: number;
+	receiverKeyId: number;
+	contentType: string;
+	from: string;
+	to: string;
+}): never {
+	function int4(v: number): Buffer {
+		const b = Buffer.alloc(4);
+		b.writeInt32BE(v, 0);
+		return b;
+	}
+	return {
+		from: opts.from,
+		to: opts.to,
+		toType: "USER",
+		contentType: opts.contentType,
+		contentMetadata: { e2eeVersion: "2" },
+		chunks: [
+			Buffer.alloc(16), // salt
+			Buffer.alloc(64), // message+tag
+			Buffer.alloc(12), // sign/iv
+			int4(opts.senderKeyId),
+			int4(opts.receiverKeyId),
+		],
+	} as never;
+}
+
+Deno.test("decryptE2EEDataMessage — received: looks up self-key by receiverKeyId (#88)", async () => {
+	const oldKey = { privKey: "AAAA", pubKey: "BBBB" };
+	const newKey = { privKey: "CCCC", pubKey: "DDDD" };
+	const { e2ee, seen, lookups } = makeE2EE({
+		keysByKeyId: { "9": oldKey, "11": newKey },
+		latestKey: newKey,
+		receiverPubKey: Buffer.alloc(32),
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 9,
+		contentType: "IMAGE",
+		from: "u-them",
+		to: "u-self",
+	});
+	const out = await e2ee.decryptE2EEDataMessage(msg);
+	// The stub returned the keyMaterial/fileName we set above.
+	assertEquals(out.fileName, "x");
+	// Verify the by-id lookup happened for receiverKeyId=9, not 11.
+	assert(lookups.includes("9"), "expected by-keyId lookup for 9");
+	assertEquals(
+		Buffer.from(oldKey.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+});
+
+Deno.test("decryptE2EEDataMessage — sent: looks up self-key by senderKeyId (#88)", async () => {
+	const key7 = { privKey: "AAAA", pubKey: "BBBB" };
+	const key11 = { privKey: "CCCC", pubKey: "DDDD" };
+	const { e2ee, seen, lookups } = makeE2EE({
+		keysByKeyId: { "7": key7, "11": key11 },
+		latestKey: key11,
+		receiverPubKey: Buffer.alloc(32),
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 11,
+		contentType: "IMAGE",
+		from: "u-self", // I sent it
+		to: "u-them",
+	});
+	await e2ee.decryptE2EEDataMessage(msg);
+	assert(lookups.includes("7"), "expected by-keyId lookup for senderKeyId 7");
+	assertEquals(
+		Buffer.from(key7.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+});
+
+Deno.test("decryptE2EEDataMessage — falls back to latest key when by-id miss (#88)", async () => {
+	const newKey = { privKey: "ZZZZ", pubKey: "YYYY" };
+	const { e2ee, seen } = makeE2EE({
+		keysByKeyId: {}, // empty by-id store
+		latestKey: newKey,
+		receiverPubKey: Buffer.alloc(32),
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 9,
+		contentType: "IMAGE",
+		from: "u-them",
+		to: "u-self",
+	});
+	await e2ee.decryptE2EEDataMessage(msg);
+	assertEquals(
+		Buffer.from(newKey.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+});

--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -696,22 +696,33 @@ export class E2EE {
 		this.e2eeLog("decryptE2EETextMessageSenderKeyId", senderKeyId);
 		this.e2eeLog("decryptE2EETextMessageReceiverKeyId", receiverKeyId);
 
-		const selfKey = await this.getE2EESelfKeyData(this.client.profile!.mid);
-		let privK = Buffer.from(selfKey.privKey, "base64");
+		let privK: Buffer;
 		let pubK: LooseType;
+		let selfPubKey: Buffer | undefined;
 
 		if (toType === LINETypes.enums.MIDType.USER || toType === "USER") {
+			// #88: select self-key by the id LINE used at encrypt time, not
+			// the latest one — survives key rotation between messages.
+			const selfKeyId = isSelf ? senderKeyId : receiverKeyId;
+			let selfKey = await this.getE2EESelfKeyDataByKeyId(selfKeyId);
+			if (!selfKey) {
+				selfKey = await this.getE2EESelfKeyData(this.client.profile!.mid);
+			}
+			privK = Buffer.from(selfKey.privKey, "base64");
+			selfPubKey = Buffer.from(selfKey.pubKey, "base64");
 			pubK = await this.getE2EELocalPublicKey(
 				isSelf ? to : _from,
 				isSelf ? receiverKeyId : senderKeyId,
 			);
 		} else {
+			const selfKey = await this.getE2EESelfKeyData(this.client.profile!.mid);
+			selfPubKey = Buffer.from(selfKey.pubKey, "base64");
 			const groupK = await this.getE2EELocalPublicKey(
 				to,
 				receiverKeyId,
 			) as GroupKey;
 			privK = Buffer.from(groupK.privKey, "base64");
-			pubK = Buffer.from(selfKey.pubKey, "base64");
+			pubK = selfPubKey;
 			if (_from !== this.client.profile?.mid) {
 				pubK = await this.getE2EELocalPublicKey(_from, senderKeyId);
 			}
@@ -830,11 +841,6 @@ export class E2EE {
 		const receiverKeyId = byte2int(chunks[4]);
 		this.e2eeLog("decryptE2EEDataMessageSenderKeyId", senderKeyId);
 		this.e2eeLog("decryptE2EEDataMessageReceiverKeyId", receiverKeyId);
-		// Diagnostic for issue #88 — when 1:1 media decryption fails with
-		// "Unsupported state or unable to authenticate data" we need to see
-		// exactly which byte the AAD was built from.  Text in the same chat
-		// works, so capture enough state here to bisect against a real LINE
-		// ciphertext sample.
 		this.e2eeLog("decryptE2EEDataMessageEnvelope", {
 			toType,
 			specVersion,
@@ -848,18 +854,37 @@ export class E2EE {
 			),
 		});
 
-		const selfKey = await this.getE2EESelfKeyData(
-			this.client.profile?.mid as string,
-		);
-		let privK = Buffer.from(selfKey.privKey, "base64");
+		let privK: Buffer;
 		let pubK: LooseType;
 
 		if (toType === LINETypes.enums.MIDType.USER || toType === "USER") {
+			// Fix for #88: a received 1:1 message was encrypted against the
+			// `receiverKeyId` LINE picked for *us* at encrypt time — that may
+			// not be our current default self-key if E2EE keys rotated since.
+			// Look up the specific self-key by id (matches CHRLINE-Patch's
+			// "patch to use correct key by id"); the previous code path used
+			// the latest self-key blindly and ECDH'd to a wrong shared
+			// secret, causing the GCM auth tag to fail.
+			const selfKeyId = isSelf ? senderKeyId : receiverKeyId;
+			let selfKey = await this.getE2EESelfKeyDataByKeyId(selfKeyId);
+			if (!selfKey) {
+				// Fall back to the latest known self-key — covers the case
+				// where the by-id store is empty (first run / pre-migration
+				// storage layouts).
+				selfKey = await this.getE2EESelfKeyData(
+					this.client.profile?.mid as string,
+				);
+			}
+			privK = Buffer.from(selfKey.privKey, "base64");
 			pubK = await this.getE2EELocalPublicKey(
 				isSelf ? to : _from,
 				isSelf ? receiverKeyId : senderKeyId,
 			);
 		} else {
+			const selfKey = await this.getE2EESelfKeyData(
+				this.client.profile?.mid as string,
+			);
+			privK = Buffer.from(selfKey.privKey, "base64");
 			const groupK = await this.getE2EELocalPublicKey(
 				to,
 				receiverKeyId,


### PR DESCRIPTION
## Summary
Closes #88.

\`decryptE2EEDataMessage\` and \`decryptE2EETextMessage\` previously loaded the *latest* self private key for any received 1:1 message.  When E2EE keys had rotated between encrypt and decrypt time, the ECDH shared secret no longer matched, and GCM auth failed with "Unsupported state or unable to authenticate data".

Root cause was found by diffing against CHRLINE-Patch's e2ee.py, which carries a marked patch:

\`\`\`python
# patch to use correct key by id
selfKeyId = receiverKeyId if from_type == 1 else senderKeyId
selfKey = self.client.getE2EESelfKeyDataByKeyId(selfKeyId)
\`\`\`

linejs now does the same:
- \`isSelf ? senderKeyId : receiverKeyId\` selects the keyId
- \`getE2EESelfKeyDataByKeyId(selfKeyId)\` looks up the pinned private key
- Falls back to \`getE2EESelfKeyData(mid)\` (latest) when the by-id store is empty (pre-migration storage layouts)

Explains why text in the same chat decrypted while media failed: the original repro likely had media sent *after* a key rotation; older text messages still ECDH'd correctly because they were encrypted under the older self-key that happened to still be the default at decrypt time.

## Test plan
- [x] \`packages/linejs/base/e2ee/key_selection.test.ts\` — 3 tests covering received / sent / fallback paths
- [x] 39/39 \`deno test --allow-all packages/\`
- [x] \`deno check packages/linejs/base/mod.ts\`