### PR TITLE
v2.9.1: pin LineAi default host from smali static analysis

### DIFF
--- a/packages/agent/line_ai.test.ts
+++ b/packages/agent/line_ai.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { LineAiClient, LineAiEndpoints } from "./line_ai.ts";
 
 function mockFetch(): {
@@ -45,10 +45,15 @@ function mockFetch(): {
 	};
 }
 
-Deno.test("LineAiClient — defaults to provisional gw host", () => {
-	const c = new LineAiClient({ accessToken: "tok", lineVersion: "26.6.2" });
-	// Has a usable host without user supplying one (#157 — actual host TBD).
-	assert(c);
+Deno.test("LineAiClient — defaults to release host from smali", async () => {
+	const m = mockFetch();
+	const c = new LineAiClient({
+		accessToken: "tok",
+		lineVersion: "26.6.2",
+		fetch: m.fetch,
+	});
+	await c.getServiceInfo();
+	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/service-info");
 });
 
 Deno.test("LineAiClient.query — POST /v2/query-ai with X-ACCESS-TOKEN + X-LINE-VERSION", async () => {
@@ -73,7 +78,7 @@ Deno.test("LineAiClient.query — POST /v2/query-ai with X-ACCESS-TOKEN + X-LINE
 	assertEquals(body.prompt, "hello");
 	assertEquals(body.threadId, null);
 	assertEquals(r.rateLimit.remaining, "99");
-	assert(r.body && typeof r.body === "object");
+	assertEquals(typeof r.body, "object");
 });
 
 Deno.test("LineAiClient.getThread — GET /v2/thread/<id>", async () => {

--- a/packages/agent/line_ai.ts
+++ b/packages/agent/line_ai.ts
@@ -1,7 +1,6 @@
-// Native LINE AI ("Agent i" home-tab tile) REST client.
-// Endpoints + headers from smali (smali_classes8/fk2/*); host is a
-// best-guess default — Hilt-injected at runtime, override via opts.host
-// once a wire trace lands (#157).
+// Native LINE AI ("Agent i" home-tab) REST client.
+// Host + endpoints + headers extracted from LINE Android 26.6.2 smali
+// (de8/c pswitch_1, smali_classes8/fk2/*).
 import type {} from "node:buffer";
 
 export const LineAiEndpoints = {
@@ -14,8 +13,10 @@ export const LineAiEndpoints = {
 	promptPreset: "/prompt-preset",
 } as const;
 
-/** Provisional default host — override if/when the live host is known. */
-export const DEFAULT_LINE_AI_HOST = "https://gw.line.naver.jp/lineai";
+/** Release-phase host from smali de8/c. */
+export const LINE_AI_HOST_RELEASE = "https://line-x-openai.line-apps.com";
+/** Alpha-phase host (dev-menu opt-in). */
+export const LINE_AI_HOST_ALPHA = "https://line-x-openai.line-apps-alpha.com";
 
 export interface LineAiOptions {
 	accessToken: string;
@@ -46,7 +47,7 @@ export class LineAiClient {
 
 	constructor(opts: LineAiOptions) {
 		this.#opts = {
-			host: (opts.host ?? DEFAULT_LINE_AI_HOST).replace(/\/+$/, ""),
+			host: (opts.host ?? LINE_AI_HOST_RELEASE).replace(/\/+$/, ""),
 			accessToken: opts.accessToken,
 			lineVersion: opts.lineVersion,
 			fetch: opts.fetch ?? fetch,


### PR DESCRIPTION
## Summary

Found the real LINE AI host via static analysis. The AiGwApi constructor (\`fk2/a\`) takes a host-provider lambda (\`c:Lde8/c\`) whose \`invoke()\` walks a packed-switch and returns:

- RELEASE phase → \`line-x-openai.line-apps.com\`
- alpha phase (dev-menu \`use_alpha_server_key\` opt-in) → \`line-x-openai.line-apps-alpha.com\`

(\`decompiled/base/smali/smali_classes4/de8/c.smali\`, \`pswitch_1\`)

\`LineAiClient\` now uses the release host by default, no caller-supplied host needed. \`LINE_AI_HOST_RELEASE\` / \`LINE_AI_HOST_ALPHA\` exported for callers that want explicit control.

## Test plan
- [x] 46/46 \`deno test --allow-all packages/\`