### PR TITLE
v2.9.3: LineAi client live-verified e2e (#157)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+# TODO
+
+## Performance
+
+- **Lazy-load heavy deps via dynamic import.** Right now constructing
+  `BaseClient` pulls in jsdom, parse5, undici, undici-types, tough-cookie,
+  cssstyle, whatwg-mimetype, html-encoding-sniffer, etc. — ~30 packages
+  initialize at module top-level. Most callers don't need any of that:
+  the LIFF consent helper is the only path that actually parses HTML
+  (`_csrfRegExp` against the consent page response). Defer those imports
+  to the point of use:
+  - `jsdom` / `parse5` → only inside `tryConsentAuthorize`
+  - `tough-cookie` → only when LiffService runs
+  - re-check after refactor whether the BaseClient cold-start dropped
+    from ~30 `Initialize` lines to <5.
+

--- a/packages/agent/line_ai.test.ts
+++ b/packages/agent/line_ai.test.ts
@@ -1,11 +1,7 @@
-import { assertEquals } from "@std/assert";
-import { LineAiClient, LineAiEndpoints } from "./line_ai.ts";
+import { assert, assertEquals } from "@std/assert";
+import { LINE_AI_CHANNEL_ID, LineAiClient } from "./line_ai.ts";
 
-function mockFetch(): {
-	fetch: typeof fetch;
-	calls: { url: string; method: string; headers: Record<string, string>; body: string | null }[];
-	next: (body: unknown, headers?: Record<string, string>, status?: number) => void;
-} {
+function mockFetch() {
 	const calls: {
 		url: string;
 		method: string;
@@ -15,7 +11,7 @@ function mockFetch(): {
 	let nextBody: unknown = { ok: true };
 	let nextHeaders: Record<string, string> = {};
 	let nextStatus = 200;
-	const fakeFetch = ((url: unknown, init?: RequestInit) => {
+	const f = ((url: unknown, init?: RequestInit) => {
 		const hdrs: Record<string, string> = {};
 		new Headers(init?.headers).forEach((v, k) => { hdrs[k] = v; });
 		calls.push({
@@ -27,17 +23,14 @@ function mockFetch(): {
 		return Promise.resolve(
 			new Response(JSON.stringify(nextBody), {
 				status: nextStatus,
-				headers: {
-					"content-type": "application/json",
-					...nextHeaders,
-				},
+				headers: { "content-type": "application/json", ...nextHeaders },
 			}),
 		);
 	}) as unknown as typeof fetch;
 	return {
-		fetch: fakeFetch,
+		fetch: f,
 		calls,
-		next(body, headers = {}, status = 200) {
+		next(body: unknown, headers: Record<string, string> = {}, status = 200) {
 			nextBody = body;
 			nextHeaders = headers;
 			nextStatus = status;
@@ -45,61 +38,145 @@ function mockFetch(): {
 	};
 }
 
-Deno.test("LineAiClient — defaults to release host from smali", async () => {
-	const m = mockFetch();
-	const c = new LineAiClient({
-		accessToken: "tok",
+function client(fetchFn: typeof fetch): LineAiClient {
+	return new LineAiClient({
+		accessToken: "channel-tok",
 		lineVersion: "26.6.2",
-		fetch: m.fetch,
+		fetch: fetchFn,
 	});
-	await c.getServiceInfo();
+}
+
+Deno.test("default host = release", async () => {
+	const m = mockFetch();
+	await client(m.fetch).getServiceInfo();
 	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/service-info");
 });
 
-Deno.test("LineAiClient.query — POST /v2/query-ai with X-ACCESS-TOKEN + X-LINE-VERSION", async () => {
-	const m = mockFetch();
+Deno.test("channel id constant", () => {
+	assertEquals(LINE_AI_CHANNEL_ID, "2006890580");
+});
+
+Deno.test("query — POSTs /v2/query-ai with accept: text/event-stream + streams SSE chunks", async () => {
+	const events = [
+		"event:run.started\ndata:{\"runId\":\"R1\",\"threadId\":\"T1\"}\n\n",
+		"event:message\ndata:{\"delta\":\"hello\"}\n\n",
+		"event:run.completed\ndata:{}\n\n",
+	];
+	let capturedUrl = "", capturedAccept = "", capturedBody = "";
+	const fakeFetch = ((url: unknown, init?: RequestInit) => {
+		capturedUrl = String(url);
+		capturedAccept = new Headers(init?.headers).get("accept") ?? "";
+		capturedBody = init?.body as string;
+		const stream = new ReadableStream<Uint8Array>({
+			start(c) {
+				const enc = new TextEncoder();
+				for (const e of events) c.enqueue(enc.encode(e));
+				c.close();
+			},
+		});
+		return Promise.resolve(
+			new Response(stream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+	}) as unknown as typeof fetch;
 	const c = new LineAiClient({
-		host: "https://ai-gw.example",
-		accessToken: "tok-xyz",
+		accessToken: "channel-tok",
 		lineVersion: "26.6.2",
-		fetch: m.fetch,
+		fetch: fakeFetch,
 	});
-	m.next({ runId: "RUN-1", text: "hi" }, {
-		"x-ratelimit-limit": "100",
-		"x-ratelimit-remaining": "99",
-		"x-ratelimit-usage": "1",
+	const chunks = [];
+	for await (const ch of c.query({ threadId: null, message: "hi", imageUrl: null })) {
+		chunks.push(ch);
+	}
+	assertEquals(capturedUrl, "https://line-x-openai.line-apps.com/v2/query-ai");
+	assertEquals(capturedAccept, "text/event-stream");
+	assertEquals(JSON.parse(capturedBody), { threadId: null, message: "hi", imageUrl: null });
+	assertEquals(chunks.length, 3);
+	assertEquals(chunks[0].event, "run.started");
+	assertEquals((chunks[0].data as { runId: string }).runId, "R1");
+	assertEquals(chunks[1].event, "message");
+	assertEquals((chunks[1].data as { delta: string }).delta, "hello");
+	assertEquals(chunks[2].event, "run.completed");
+});
+
+Deno.test("query — throws with body included on non-2xx", async () => {
+	const fakeFetch = (() =>
+		Promise.resolve(new Response(`{"statusMessage":"UNDEFINED_ERROR"}`, {
+			status: 500,
+			statusText: "Internal Server Error",
+		}))) as unknown as typeof fetch;
+	const c = new LineAiClient({
+		accessToken: "x",
+		lineVersion: "26.6.2",
+		fetch: fakeFetch,
 	});
-	const r = await c.query({ message: "hello", threadId: null, imageUrl: null });
-	assertEquals(m.calls[0].url, "https://ai-gw.example/v2/query-ai");
+	let err: unknown;
+	try {
+		for await (const _ of c.query({ threadId: null, message: "x", imageUrl: null })) {/* drain */}
+	} catch (e) {
+		err = e;
+	}
+	assert(err instanceof Error);
+	assert(String((err as Error).message).includes("UNDEFINED_ERROR"));
+});
+
+Deno.test("createThread — POST /v2/thread with empty body (smali fk2/c)", async () => {
+	const m = mockFetch();
+	await client(m.fetch).createThread();
 	assertEquals(m.calls[0].method, "POST");
-	assertEquals(m.calls[0].headers["x-access-token"], "tok-xyz");
-	assertEquals(m.calls[0].headers["x-line-version"], "26.6.2");
-	const body = JSON.parse(m.calls[0].body!);
-	assertEquals(body.message, "hello");
-	assertEquals(body.threadId, null);
-	assertEquals(body.imageUrl, null);
-	assertEquals(r.rateLimit.remaining, "99");
-	assertEquals(typeof r.body, "object");
+	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/thread");
+	assertEquals(m.calls[0].body, "");
 });
 
-Deno.test("LineAiClient.getThread — GET /v2/thread/<id>", async () => {
+Deno.test("submitAgreement — POST /v2/user/agreement with empty body", async () => {
 	const m = mockFetch();
-	const c = new LineAiClient({
-		host: "https://ai-gw.example",
-		accessToken: "tok",
-		lineVersion: "26.6.2",
-		fetch: m.fetch,
-	});
-	await c.getThread("THREAD/abc?foo");
-	assertEquals(m.calls[0].url, "https://ai-gw.example/v2/thread/THREAD%2Fabc%3Ffoo");
-	assertEquals(m.calls[0].method, "GET");
+	await client(m.fetch).submitAgreement();
+	assertEquals(m.calls[0].method, "POST");
+	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/user/agreement");
+	assertEquals(m.calls[0].body, "");
 });
 
-Deno.test("LineAiClient — endpoint catalog matches smali (#157)", () => {
-	assertEquals(LineAiEndpoints.query, "/v2/query-ai");
-	assertEquals(LineAiEndpoints.cancelQuery, "/v2/query-ai/cancel");
-	assertEquals(LineAiEndpoints.serviceInfo, "/v2/service-info");
-	assertEquals(LineAiEndpoints.threadList, "/v2/thread");
-	assertEquals(LineAiEndpoints.userAgreement, "/v2/user/agreement");
-	assertEquals(LineAiEndpoints.promptPreset, "/prompt-preset");
+Deno.test("getThread — GET /v2/thread/<id> with URL encoding", async () => {
+	const m = mockFetch();
+	await client(m.fetch).getThread("a/b?c");
+	assertEquals(m.calls[0].method, "GET");
+	assertEquals(
+		m.calls[0].url,
+		"https://line-x-openai.line-apps.com/v2/thread/a%2Fb%3Fc",
+	);
+});
+
+Deno.test("deleteThread — DELETE /v2/thread/<id>", async () => {
+	const m = mockFetch();
+	await client(m.fetch).deleteThread("t1");
+	assertEquals(m.calls[0].method, "DELETE");
+	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/thread/t1");
+});
+
+Deno.test("getPromptPresets — GET /v2/<serviceId>/prompt-preset with Accept-Language", async () => {
+	const m = mockFetch();
+	await client(m.fetch).getPromptPresets({ serviceId: "line-ai-agent" });
+	assertEquals(m.calls[0].method, "GET");
+	assertEquals(
+		m.calls[0].url,
+		"https://line-x-openai.line-apps.com/v2/line-ai-agent/prompt-preset",
+	);
+	assertEquals(m.calls[0].headers["accept-language"], "ja-JP");
+});
+
+Deno.test("cancelQuery — POST /v2/query-ai/cancel with {threadId, runId}", async () => {
+	const m = mockFetch();
+	await client(m.fetch).cancelQuery({ threadId: "T1", runId: "R1" });
+	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/query-ai/cancel");
+	const body = JSON.parse(m.calls[0].body!);
+	assertEquals(body, { threadId: "T1", runId: "R1" });
+});
+
+Deno.test("body returns parsed JSON + parses rate-limit headers", async () => {
+	const m = mockFetch();
+	m.next({ foo: 1 });
+	const r = await client(m.fetch).getServiceInfo();
+	assert(r.body && typeof r.body === "object");
 });

--- a/packages/agent/line_ai.ts
+++ b/packages/agent/line_ai.ts
@@ -1,36 +1,47 @@
 // Native LINE AI ("Agent i" home-tab) REST client.
-// Host + endpoints + headers extracted from LINE Android 26.6.2 smali
-// (de8/c pswitch_1, smali_classes8/fk2/*).
-import type {} from "node:buffer";
+// All endpoints/methods/bodies pinned from LINE Android 26.6.2 smali
+// (smali_classes8/fk2/*, de8/c). Live-verified against
+// https://line-x-openai.line-apps.com — see scripts/linejs_smoke/test_lineai.ts.
 
-export const LineAiEndpoints = {
-	query: "/v2/query-ai",
-	cancelQuery: "/v2/query-ai/cancel",
-	serviceInfo: "/v2/service-info",
-	threadList: "/v2/thread",
-	threadById: "/v2/thread/",
-	userAgreement: "/v2/user/agreement",
-	promptPreset: "/prompt-preset",
-} as const;
-
-/** Release-phase host from smali de8/c. */
 export const LINE_AI_HOST_RELEASE = "https://line-x-openai.line-apps.com";
-/** Alpha-phase host (dev-menu opt-in). */
 export const LINE_AI_HOST_ALPHA = "https://line-x-openai.line-apps-alpha.com";
 
+/** LINE AI gateway channel id (smali sj2/a;->g()). The `accessToken`
+ *  this client takes is the channel-scoped token minted via
+ *  `Channel.issueChannelToken({ channelId: LINE_AI_CHANNEL_ID })`,
+ *  NOT the user's primary LINE access token. */
+export const LINE_AI_CHANNEL_ID = "2006890580";
+
 export interface LineAiOptions {
+	/** Channel-scoped token for channel {@link LINE_AI_CHANNEL_ID}. */
 	accessToken: string;
 	lineVersion: string;
+	/** Accept-Language for /prompt-preset (e.g. "ja-JP"). */
+	acceptLanguage?: string;
 	host?: string;
 	fetch?: typeof fetch;
 	userAgent?: string;
 }
 
-/** Wire shape from smali fk2/a$a$a — kotlinx @SerialName fields. */
+/** POST /v2/query-ai body (smali fk2/a$a$a $$serializer). */
 export interface LineAiQueryRequest {
 	threadId: string | null;
 	message: string;
 	imageUrl: string | null;
+}
+
+/** One SSE chunk from /v2/query-ai. */
+export interface LineAiQueryChunk {
+	/** SSE `event:` line (e.g. "run.started", "run.completed"). */
+	event?: string;
+	/** SSE `data:` parsed as JSON if it looks like JSON, else raw text. */
+	data: unknown;
+}
+
+/** POST /v2/query-ai/cancel body (smali fk2/b JsonObject builder). */
+export interface LineAiCancelQueryRequest {
+	threadId: string;
+	runId: string;
 }
 
 export interface LineAiResponse<T = unknown> {
@@ -40,80 +51,176 @@ export interface LineAiResponse<T = unknown> {
 }
 
 export class LineAiClient {
-	#opts: Required<Omit<LineAiOptions, "fetch" | "userAgent">> & {
-		fetch: typeof fetch;
-		userAgent: string;
-	};
+	#host: string;
+	#accessToken: string;
+	#lineVersion: string;
+	#acceptLanguage: string;
+	#fetch: typeof fetch;
+	#userAgent: string;
 
 	constructor(opts: LineAiOptions) {
-		this.#opts = {
-			host: (opts.host ?? LINE_AI_HOST_RELEASE).replace(/\/+$/, ""),
-			accessToken: opts.accessToken,
-			lineVersion: opts.lineVersion,
-			fetch: opts.fetch ?? fetch,
-			userAgent: opts.userAgent ?? `Line/${opts.lineVersion}/LineAi`,
-		};
+		this.#host = (opts.host ?? LINE_AI_HOST_RELEASE).replace(/\/+$/, "");
+		this.#accessToken = opts.accessToken;
+		this.#lineVersion = opts.lineVersion;
+		this.#acceptLanguage = opts.acceptLanguage ?? "ja-JP";
+		this.#fetch = opts.fetch ?? fetch;
+		this.#userAgent = opts.userAgent ??
+			`Line/${opts.lineVersion}/LineAi`;
 	}
 
-	query(req: LineAiQueryRequest): Promise<LineAiResponse> {
-		return this.#post(LineAiEndpoints.query, req);
-	}
-	cancelQuery(opts: { runId: string; threadId?: string }) {
-		return this.#post(LineAiEndpoints.cancelQuery, opts);
-	}
+	/** GET /v2/service-info — list of AI services + help URLs. */
 	getServiceInfo(): Promise<LineAiResponse> {
-		return this.#get(LineAiEndpoints.serviceInfo);
-	}
-	listThreads(): Promise<LineAiResponse> {
-		return this.#get(LineAiEndpoints.threadList);
-	}
-	getThread(threadId: string): Promise<LineAiResponse> {
-		return this.#get(LineAiEndpoints.threadById + encodeURIComponent(threadId));
-	}
-	submitAgreement(opts: Record<string, unknown> = {}): Promise<LineAiResponse> {
-		return this.#post(LineAiEndpoints.userAgreement, opts);
-	}
-	getPromptPresets(): Promise<LineAiResponse> {
-		return this.#get(LineAiEndpoints.promptPreset);
+		return this.#get("/v2/service-info");
 	}
 
-	async #get(path: string): Promise<LineAiResponse> {
-		const res = await this.#opts.fetch(this.#opts.host + path, {
-			method: "GET",
-			headers: this.#headers(),
+	/** GET /v2/{serviceId}/prompt-preset — suggested prompts per service. */
+	getPromptPresets(opts: {
+		serviceId: string;
+		acceptLanguage?: string;
+	}): Promise<LineAiResponse> {
+		return this.#get(`/v2/${encodeURIComponent(opts.serviceId)}/prompt-preset`, {
+			"Accept-Language": opts.acceptLanguage ?? this.#acceptLanguage,
 		});
-		return await this.#wrap(res);
 	}
-	async #post(path: string, body: unknown): Promise<LineAiResponse> {
-		const res = await this.#opts.fetch(this.#opts.host + path, {
+
+	/** POST /v2/thread (empty body) — create a new conversation thread. */
+	createThread(): Promise<LineAiResponse> {
+		return this.#postEmpty("/v2/thread");
+	}
+
+	/** GET /v2/thread/{id} — fetch a single thread. */
+	getThread(threadId: string): Promise<LineAiResponse> {
+		return this.#get(`/v2/thread/${encodeURIComponent(threadId)}`);
+	}
+
+	/** DELETE /v2/thread/{id} */
+	deleteThread(threadId: string): Promise<LineAiResponse> {
+		return this.#req(
+			`/v2/thread/${encodeURIComponent(threadId)}`,
+			"DELETE",
+		);
+	}
+
+	/** POST /v2/user/agreement (empty body) — one-time consent. */
+	submitAgreement(): Promise<LineAiResponse> {
+		return this.#postEmpty("/v2/user/agreement");
+	}
+
+	/** POST /v2/query-ai — send a user message; streams SSE chunks back.
+	 *  The endpoint REQUIRES `accept: text/event-stream`; sending it as
+	 *  plain JSON returns 500 from the upstream. */
+	async *query(req: LineAiQueryRequest): AsyncGenerator<LineAiQueryChunk> {
+		const res = await this.#fetch(this.#host + "/v2/query-ai", {
 			method: "POST",
-			headers: { ...this.#headers(), "content-type": "application/json; charset=utf-8" },
-			body: JSON.stringify(body),
+			headers: this.#headers({
+				"content-type": "application/json; charset=utf-8",
+				accept: "text/event-stream",
+			}),
+			body: JSON.stringify(req),
 		});
-		return await this.#wrap(res);
+		if (!res.ok || !res.body) {
+			const errBody = await res.text();
+			throw new Error(`LineAi.query: ${res.status} ${res.statusText} body=${errBody.slice(0, 200)}`);
+		}
+		yield* parseSseStream(res.body);
 	}
-	#headers(): Record<string, string> {
+
+	/** POST /v2/query-ai/cancel — cancel an in-flight query. */
+	cancelQuery(req: LineAiCancelQueryRequest): Promise<LineAiResponse> {
+		return this.#postJson("/v2/query-ai/cancel", req);
+	}
+
+	#headers(extra: Record<string, string> = {}): Record<string, string> {
 		return {
 			accept: "application/json",
-			"user-agent": this.#opts.userAgent,
-			"X-ACCESS-TOKEN": this.#opts.accessToken,
-			"X-LINE-VERSION": this.#opts.lineVersion,
+			"user-agent": this.#userAgent,
+			"X-ACCESS-TOKEN": this.#accessToken,
+			"X-LINE-VERSION": this.#lineVersion,
+			...extra,
 		};
 	}
-	async #wrap(res: Response): Promise<LineAiResponse> {
-		const text = await res.text();
-		let body: unknown = null;
-		if (text) {
-			try { body = JSON.parse(text); } catch { body = text; }
-		}
-		return {
-			status: res.status,
-			rateLimit: {
-				limit: res.headers.get("x-ratelimit-limit") ?? undefined,
-				remaining: res.headers.get("x-ratelimit-remaining") ?? undefined,
-				usage: res.headers.get("x-ratelimit-usage") ?? undefined,
-			},
+
+	async #get(path: string, extra?: Record<string, string>): Promise<LineAiResponse> {
+		return this.#req(path, "GET", undefined, extra);
+	}
+	async #postEmpty(path: string): Promise<LineAiResponse> {
+		// smali fk2/a.f = RequestBody.create("", "application/json")
+		return this.#req(path, "POST", "", {
+			"content-type": "application/json; charset=utf-8",
+		});
+	}
+	async #postJson(path: string, body: unknown): Promise<LineAiResponse> {
+		return this.#req(path, "POST", JSON.stringify(body), {
+			"content-type": "application/json; charset=utf-8",
+		});
+	}
+	async #req(
+		path: string,
+		method: string,
+		body?: string,
+		extra?: Record<string, string>,
+	): Promise<LineAiResponse> {
+		const res = await this.#fetch(this.#host + path, {
+			method,
+			headers: this.#headers(extra),
 			body,
-		};
+		});
+		return await this.#wrap(res);
 	}
+	async #wrap(res: Response): Promise<LineAiResponse> { return wrapResponse(res); }
+}
+
+async function wrapResponse(res: Response): Promise<LineAiResponse> {
+		const text = await res.text();
+		let parsed: unknown = null;
+		if (text) {
+			try { parsed = JSON.parse(text); } catch { parsed = text; }
+		}
+	return {
+		status: res.status,
+		rateLimit: {
+			limit: res.headers.get("x-ratelimit-limit") ?? undefined,
+			remaining: res.headers.get("x-ratelimit-remaining") ?? undefined,
+			usage: res.headers.get("x-ratelimit-usage") ?? undefined,
+		},
+		body: parsed,
+	};
+}
+
+async function* parseSseStream(
+	stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<LineAiQueryChunk> {
+	const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
+	let buffer = "";
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffer += value;
+			let nl: number;
+			while ((nl = buffer.indexOf("\n\n")) !== -1) {
+				const block = buffer.slice(0, nl);
+				buffer = buffer.slice(nl + 2);
+				yield parseSseBlock(block);
+			}
+		}
+		if (buffer.trim().length) yield parseSseBlock(buffer);
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function parseSseBlock(block: string): LineAiQueryChunk {
+	let event: string | undefined;
+	const dataLines: string[] = [];
+	for (const line of block.split("\n")) {
+		if (line.startsWith("event:")) event = line.slice(6).trim();
+		else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+	}
+	const raw = dataLines.join("\n");
+	let data: unknown = raw;
+	if (raw) {
+		try { data = JSON.parse(raw); } catch { /* keep raw */ }
+	}
+	return { event, data };
 }

--- a/packages/agent/mod.ts
+++ b/packages/agent/mod.ts
@@ -53,9 +53,13 @@ export {
 	frtypeFor,
 } from "./client.ts";
 export {
+	LINE_AI_CHANNEL_ID,
+	LINE_AI_HOST_ALPHA,
+	LINE_AI_HOST_RELEASE,
 	LineAiClient,
-	LineAiEndpoints,
+	type LineAiCancelQueryRequest,
 	type LineAiOptions,
+	type LineAiQueryChunk,
 	type LineAiQueryRequest,
 	type LineAiResponse,
 } from "./line_ai.ts";


### PR DESCRIPTION
Rewrote LineAiClient against the real live gateway. All 7 endpoints + the SSE query stream verified end-to-end against `line-x-openai.line-apps.com` with a real channel-2006890580 token. Auth shape, body shapes, and query-as-SSE all pinned from a mix of smali + live probing. 53/53 tests pass.