### PR TITLE
v2.9.9: LineAi promptPreset takes contextType, not serviceId

### DIFF
--- a/packages/agent/line_ai.test.ts
+++ b/packages/agent/line_ai.test.ts
@@ -155,13 +155,13 @@ Deno.test("deleteThread — DELETE /v2/thread/<id>", async () => {
 	assertEquals(m.calls[0].url, "https://line-x-openai.line-apps.com/v2/thread/t1");
 });
 
-Deno.test("getPromptPresets — GET /v2/<serviceId>/prompt-preset with Accept-Language", async () => {
+Deno.test("getPromptPresets — GET /v2/<contextType>/prompt-preset with Accept-Language (live-verified)", async () => {
 	const m = mockFetch();
-	await client(m.fetch).getPromptPresets({ serviceId: "line-ai-agent" });
+	await client(m.fetch).getPromptPresets({ contextType: "trending" });
 	assertEquals(m.calls[0].method, "GET");
 	assertEquals(
 		m.calls[0].url,
-		"https://line-x-openai.line-apps.com/v2/line-ai-agent/prompt-preset",
+		"https://line-x-openai.line-apps.com/v2/trending/prompt-preset",
 	);
 	assertEquals(m.calls[0].headers["accept-language"], "ja-JP");
 });

--- a/packages/agent/line_ai.ts
+++ b/packages/agent/line_ai.ts
@@ -6,6 +6,9 @@
 export const LINE_AI_HOST_RELEASE = "https://line-x-openai.line-apps.com";
 export const LINE_AI_HOST_ALPHA = "https://line-x-openai.line-apps-alpha.com";
 
+/** Known valid context-types for {@link LineAiClient.getPromptPresets}. */
+export type LineAiPromptContext = "trending" | "image-attached";
+
 /** LINE AI gateway channel id (smali sj2/a;->g()). The `accessToken`
  *  this client takes is the channel-scoped token minted via
  *  `Channel.issueChannelToken({ channelId: LINE_AI_CHANNEL_ID })`,
@@ -73,12 +76,15 @@ export class LineAiClient {
 		return this.#get("/v2/service-info");
 	}
 
-	/** GET /v2/{serviceId}/prompt-preset — suggested prompts per service. */
+	/** GET /v2/{contextType}/prompt-preset — suggested prompts per context.
+	 *  Live-verified context types: "trending", "image-attached" (smali
+	 *  zk2/a + zk2/d). The path segment is the context type, NOT a locale
+	 *  (server error message confirms parsing). */
 	getPromptPresets(opts: {
-		serviceId: string;
+		contextType: LineAiPromptContext | string;
 		acceptLanguage?: string;
 	}): Promise<LineAiResponse> {
-		return this.#get(`/v2/${encodeURIComponent(opts.serviceId)}/prompt-preset`, {
+		return this.#get(`/v2/${encodeURIComponent(opts.contextType)}/prompt-preset`, {
 			"Accept-Language": opts.acceptLanguage ?? this.#acceptLanguage,
 		});
 	}

--- a/packages/agent/mod.ts
+++ b/packages/agent/mod.ts
@@ -59,6 +59,7 @@ export {
 	LineAiClient,
 	type LineAiCancelQueryRequest,
 	type LineAiOptions,
+	type LineAiPromptContext,
 	type LineAiQueryChunk,
 	type LineAiQueryRequest,
 	type LineAiResponse,


### PR DESCRIPTION
Live-verified: the path segment is a context type. 'trending' + 'image-attached' return real preset lists.