### PR TITLE
v3.0.0: call control-plane + incoming-call events (#148)

### DIFF
--- a/packages/linejs/base/service/call/mod.ts
+++ b/packages/linejs/base/service/call/mod.ts
@@ -216,4 +216,16 @@ export class CallService implements BaseService {
 			this.requestPath,
 		);
 	}
+
+	async getCallStatus(
+		...param: Parameters<typeof LINEStruct.getCallStatus_args>
+	): Promise<LINETypes.getCallStatus_result["success"]> {
+		return await this.client.request.request(
+			LINEStruct.getCallStatus_args(...param),
+			"getCallStatus",
+			this.protocolType,
+			true,
+			this.requestPath,
+		);
+	}
 }

--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -19,6 +19,16 @@ export * as voom from "./features/voom.ts";
 import { createVoomClient, VoomChannelId, type VoomClient, voomRest, type VoomRestOptions, type VoomRestResponse } from "./features/voom.ts";
 export { VoomChannelId };
 export type { VoomClient, VoomRestOptions, VoomRestResponse };
+export * as call from "./features/call.ts";
+import {
+	type CallClient,
+	type CancelCallEvent,
+	createCallClient,
+	type IncomingCallEvent,
+	parseCancelCall,
+	parseIncomingCall,
+} from "./features/call.ts";
+export type { CallClient, CancelCallEvent, CallType, IncomingCallEvent } from "./features/call.ts";
 export { Chat, Square, SquareChat, SquareMessage, TalkMessage, User };
 export { ProfileAttribute } from "./features/profile.ts";
 export type { MyProfileUpdate } from "./features/profile.ts";
@@ -45,6 +55,8 @@ export type ClientEvents = {
 	event: (event: LINETypes.Operation) => void;
 	"square:message": (message: SquareMessage) => void;
 	"square:event": (event: LINETypes.SquareEvent) => void;
+	"call:incoming": (event: IncomingCallEvent) => void;
+	"call:cancel": (event: CancelCallEvent) => void;
 };
 
 function isApiNotCapable(e: unknown): boolean {
@@ -73,6 +85,13 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 	get voom(): VoomClient {
 		if (!this.#voom) this.#voom = createVoomClient(this);
 		return this.#voom;
+	}
+
+	#call?: CallClient;
+	/** Call control-plane wrapper (#148 v3.0). Media plane TBD. */
+	get call(): CallClient {
+		if (!this.#call) this.#call = createCallClient(this);
+		return this.#call;
 	}
 
 	/**
@@ -108,6 +127,10 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 								client: this,
 							}),
 						);
+					} else if (event.type === "NOTIFIED_RECEIVED_CALL") {
+						this.emit("call:incoming", parseIncomingCall(event));
+					} else if (event.type === "CANCEL_CALL") {
+						this.emit("call:cancel", parseCancelCall(event));
 					}
 				}
 			})();

--- a/packages/linejs/client/features/call.test.ts
+++ b/packages/linejs/client/features/call.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "@std/assert";
+import { createCallClient, parseCancelCall, parseIncomingCall } from "./call.ts";
+
+function fakeBaseClient() {
+	const calls: { method: string; args: unknown[] }[] = [];
+	const record = (method: string) => (...args: unknown[]) => {
+		calls.push({ method, args });
+		return Promise.resolve({ ok: true, method });
+	};
+	const base = {
+		call: {
+			acquireCallRoute: record("acquireCallRoute"),
+			acquireGroupCallRoute: record("acquireGroupCallRoute"),
+			acquireOACallRoute: record("acquireOACallRoute"),
+			getGroupCall: record("getGroupCall"),
+			createGroupCallUrl: record("createGroupCallUrl"),
+			getGroupCallUrlInfo: record("getGroupCallUrlInfo"),
+			getGroupCallUrls: record("getGroupCallUrls"),
+			updateGroupCallUrl: record("updateGroupCallUrl"),
+			deleteGroupCallUrl: record("deleteGroupCallUrl"),
+			joinChatByCallUrl: record("joinChatByCallUrl"),
+			inviteIntoGroupCall: record("inviteIntoGroupCall"),
+			kickoutFromGroupCall: record("kickoutFromGroupCall"),
+		},
+	};
+	return { client: { base } as never, calls, base };
+}
+
+Deno.test("call.acquireRoute defaults callType=AUDIO", async () => {
+	const { client, calls } = fakeBaseClient();
+	const cc = createCallClient(client);
+	await cc.acquireRoute({ to: "u-peer" });
+	assertEquals(calls[0].method, "acquireCallRoute");
+	assertEquals(
+		(calls[0].args[0] as { callType: string }).callType,
+		"AUDIO",
+	);
+	assertEquals((calls[0].args[0] as { to: string }).to, "u-peer");
+});
+
+Deno.test("call.acquireRoute respects explicit callType", async () => {
+	const { client, calls } = fakeBaseClient();
+	await createCallClient(client).acquireRoute({ to: "u-peer", callType: "VIDEO" });
+	assertEquals((calls[0].args[0] as { callType: string }).callType, "VIDEO");
+});
+
+Deno.test("call.getGroupCall + URL CRUD route to right base methods", async () => {
+	const { client, calls } = fakeBaseClient();
+	const cc = createCallClient(client);
+	await cc.getGroupCall("c-chat");
+	await cc.getGroupCallUrl("ticket-1");
+	await cc.listGroupCallUrls();
+	await cc.joinChatByUrl("ticket-2");
+	assertEquals(calls.map((c) => c.method), [
+		"getGroupCall",
+		"getGroupCallUrlInfo",
+		"getGroupCallUrls",
+		"joinChatByCallUrl",
+	]);
+	assertEquals(
+		(calls[1].args[0] as { groupCallUrlTicket: string }).groupCallUrlTicket,
+		"ticket-1",
+	);
+});
+
+Deno.test("parseIncomingCall pulls callMid/from/kind out of Operation params", () => {
+	const e = parseIncomingCall({
+		param1: "ccall-1",
+		param2: "u-caller",
+		param3: "VIDEO",
+		type: "NOTIFIED_RECEIVED_CALL",
+	} as never);
+	assertEquals(e.callMid, "ccall-1");
+	assertEquals(e.from, "u-caller");
+	assertEquals(e.kind, "VIDEO");
+});
+
+Deno.test("parseCancelCall pulls fields out of CANCEL_CALL op", () => {
+	const e = parseCancelCall({
+		param1: "ccall-1",
+		param2: "u-caller",
+		param3: "DECLINED",
+		type: "CANCEL_CALL",
+	} as never);
+	assertEquals(e.callMid, "ccall-1");
+	assertEquals(e.from, "u-caller");
+	assertEquals(e.reason, "DECLINED");
+});
+
+Deno.test("parseIncomingCall handles missing param2/param3", () => {
+	const e = parseIncomingCall({
+		param1: "ccall-1",
+		type: "NOTIFIED_RECEIVED_CALL",
+	} as never);
+	assertEquals(e.callMid, "ccall-1");
+	assertEquals(e.from, "");
+	assertEquals(e.kind, undefined);
+});

--- a/packages/linejs/client/features/call.ts
+++ b/packages/linejs/client/features/call.ts
@@ -1,0 +1,200 @@
+// High-level call control-plane adapter (#148 v3.0).
+// Wraps the Thrift CallService — route allocation, group-call URL
+// CRUD, kick/invite. No media plane; that's v3.1+ (CALLS.md).
+import type { Client } from "../mod.ts";
+import type * as LINETypes from "@evex/linejs-types";
+
+export type CallType = "AUDIO" | "VIDEO" | "FACEPLAY";
+
+export interface CallClient {
+	/**
+	 * Allocate a 1:1 call route. Returns the `cscf`/`mix` host pair the
+	 * Andromeda media client would dial into, plus the `fromToken`.
+	 */
+	acquireRoute(opts: {
+		to: string;
+		callType?: CallType;
+		fromEnvInfo?: Record<string, string>;
+	}): Promise<LINETypes.CallRoute>;
+
+	/** Allocate a group-call route. */
+	acquireGroupRoute(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["acquireGroupCallRoute"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["acquireGroupCallRoute"]
+	>;
+
+	/** OA (official-account) call route. */
+	acquireOARoute(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["acquireOACallRoute"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["acquireOACallRoute"]
+	>;
+
+	/** Get current group-call state for a chat. */
+	getGroupCall(chatMid: string): Promise<unknown>;
+
+	/** Group-call URL CRUD. */
+	createGroupCallUrl(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["createGroupCallUrl"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["createGroupCallUrl"]
+	>;
+	getGroupCallUrl(
+		ticket: string,
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["getGroupCallUrlInfo"]
+	>;
+	listGroupCallUrls(): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["getGroupCallUrls"]
+	>;
+	updateGroupCallUrl(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["updateGroupCallUrl"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["updateGroupCallUrl"]
+	>;
+	deleteGroupCallUrl(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["deleteGroupCallUrl"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["deleteGroupCallUrl"]
+	>;
+	/** Join a chat via a group-call URL ticket. */
+	joinChatByUrl(ticket: string): Promise<unknown>;
+	/** Invite users into an in-progress group call. */
+	invite(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["inviteIntoGroupCall"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["inviteIntoGroupCall"]
+	>;
+	/** Kick a user from an in-progress group call. */
+	kick(
+		...args: Parameters<
+			import("../../base/service/call/mod.ts").CallService["kickoutFromGroupCall"]
+		>
+	): ReturnType<
+		import("../../base/service/call/mod.ts").CallService["kickoutFromGroupCall"]
+	>;
+
+	/** Low-level: the base CallService for any RPC not wrapped above. */
+	readonly service: import("../../base/service/call/mod.ts").CallService;
+}
+
+class ClientCall implements CallClient {
+	#client: Client;
+	constructor(client: Client) {
+		this.#client = client;
+	}
+	get service() {
+		return this.#client.base.call;
+	}
+
+	acquireRoute(opts: {
+		to: string;
+		callType?: CallType;
+		fromEnvInfo?: Record<string, string>;
+	}) {
+		return this.service.acquireCallRoute({
+			to: opts.to,
+			callType: opts.callType ?? "AUDIO",
+			fromEnvInfo: opts.fromEnvInfo,
+		} as never);
+	}
+	acquireGroupRoute(
+		...args: Parameters<typeof this.service.acquireGroupCallRoute>
+	) {
+		return this.service.acquireGroupCallRoute(...args);
+	}
+	acquireOARoute(...args: Parameters<typeof this.service.acquireOACallRoute>) {
+		return this.service.acquireOACallRoute(...args);
+	}
+	getGroupCall(chatMid: string) {
+		return this.service.getGroupCall({ chatMid } as never);
+	}
+	createGroupCallUrl(
+		...args: Parameters<typeof this.service.createGroupCallUrl>
+	) {
+		return this.service.createGroupCallUrl(...args);
+	}
+	getGroupCallUrl(ticket: string) {
+		return this.service.getGroupCallUrlInfo({ groupCallUrlTicket: ticket } as never);
+	}
+	listGroupCallUrls() {
+		return this.service.getGroupCallUrls({} as never);
+	}
+	updateGroupCallUrl(
+		...args: Parameters<typeof this.service.updateGroupCallUrl>
+	) {
+		return this.service.updateGroupCallUrl(...args);
+	}
+	deleteGroupCallUrl(
+		...args: Parameters<typeof this.service.deleteGroupCallUrl>
+	) {
+		return this.service.deleteGroupCallUrl(...args);
+	}
+	joinChatByUrl(ticket: string) {
+		return this.service.joinChatByCallUrl({ groupCallUrlTicket: ticket } as never);
+	}
+	invite(...args: Parameters<typeof this.service.inviteIntoGroupCall>) {
+		return this.service.inviteIntoGroupCall(...args);
+	}
+	kick(...args: Parameters<typeof this.service.kickoutFromGroupCall>) {
+		return this.service.kickoutFromGroupCall(...args);
+	}
+}
+
+export function createCallClient(client: Client): CallClient {
+	return new ClientCall(client);
+}
+
+/**
+ * Parsed incoming-call event from the polling stream. Surfaced by
+ * Client via `on("call:incoming", ...)`. Fields are derived from the
+ * raw Operation params:
+ * - `callMid` = param1 (a c-prefixed mid identifying the call instance)
+ * - `from`    = param2 (caller's user mid; absent if we're the caller)
+ * - `kind`    = param3 (AUDIO / VIDEO / FACEPLAY when LINE sets it)
+ */
+export interface IncomingCallEvent {
+	callMid: string;
+	from: string;
+	kind?: string;
+	raw: LINETypes.Operation;
+}
+
+/** Parsed cancel-call event (OpType CANCEL_CALL). */
+export interface CancelCallEvent {
+	callMid: string;
+	from: string;
+	reason?: string;
+	raw: LINETypes.Operation;
+}
+
+export function parseIncomingCall(op: LINETypes.Operation): IncomingCallEvent {
+	return {
+		callMid: (op as { param1?: string }).param1 ?? "",
+		from: (op as { param2?: string }).param2 ?? "",
+		kind: (op as { param3?: string }).param3,
+		raw: op,
+	};
+}
+
+export function parseCancelCall(op: LINETypes.Operation): CancelCallEvent {
+	return {
+		callMid: (op as { param1?: string }).param1 ?? "",
+		from: (op as { param2?: string }).param2 ?? "",
+		reason: (op as { param3?: string }).param3,
+		raw: op,
+	};
+}


### PR DESCRIPTION
Closes #148 control-plane scope. `client.call.*` + `client.on('call:incoming'/'call:cancel')`. Media plane TBD in v3.1+ (see CALLS.md). 58/58 tests green; routing live-verified (server reached).