### PR TITLE
v2.15.1: clean call types + e2e audio round-trip

### DIFF
--- a/docs/docs/call.md
+++ b/docs/docs/call.md
@@ -1,0 +1,107 @@
+# Calls
+
+`client.call.*` wraps the LINE call control plane (Thrift /V4) and
+provides a `CallSession` that drives an `AndromedaTransport` for the
+media plane.
+
+## Control plane
+
+```ts
+// Allocate a 1:1 call route (returns cscf/mix/fromToken/stnpk).
+const route = await client.call.acquireRoute({
+	to: "u<peer-mid>",
+	callType: "AUDIO", // or "VIDEO" | "FACEPLAY"
+});
+
+// Group-call URLs
+const url = await client.call.createGroupCallUrl({ /* ... */ });
+const urls = await client.call.listGroupCallUrls();
+await client.call.deleteGroupCallUrl({ /* ... */ });
+
+// Incoming-call event
+client.on("call:incoming", ({ callMid, from, kind }) => {
+	console.log("incoming call from", from, "type", kind);
+});
+```
+
+## Media plane
+
+```ts
+import {
+	AndromedaTransport,
+	bufferSource,
+	bufferSink,
+	decodeWavSync,
+} from "@evex/linejs";
+
+// Plug in an Opus codec (caller supplies a WASM impl)
+client.call.setCodecFactory(myOpusCodecs);
+
+const session = client.call.startSession({
+	to: "u<peer-mid>",
+	kind: "AUDIO",
+	transport: new AndromedaTransport({ localMid: client.profile.mid }),
+});
+
+await session.start(); // acquires route + REGISTER + INVITE + ACK
+
+// Play a WAV file into the call
+const wav = await Deno.readFile("./greeting.wav");
+const pcm = decodeWavSync(wav);
+await session.sendBuffer(pcm);
+
+// Receive peer audio
+const sink = bufferSink();
+await session.receiveInto(sink);
+// sink.frames contains PCM frames
+
+await session.end();
+```
+
+## Audio pipeline
+
+- `PcmFrame { samples: Int16Array, sampleRate, channels }` — base unit.
+- `bufferSource({samples, sampleRate, frameDurationMs?})` — split a
+  PCM buffer into 20-ms frames.
+- `bufferSink()` / `streamSink(stream)` — receive frames.
+- `decodeWavSync(bytes)` — bundled 16-bit PCM WAV decoder. For mp3,
+  pass any WASM mp3 decoder via `session.sendFile({bytes, decode})`.
+- `resampleLinear(samples, fromRate, toRate, channels)` — quick
+  resample.
+
+## Codec
+
+`CodecFactory` is caller-supplied so linejs doesn't pin a specific
+Opus WASM. Pattern:
+
+```ts
+import type { CodecFactory } from "@evex/linejs";
+
+const myOpusCodecs: CodecFactory = {
+	newEncoder({ sampleRate, channels }) {
+		// Return an AudioEncoder backed by your Opus binding
+		// (encode(pcm) → Uint8Array | null)
+	},
+	newDecoder({ sampleRate, channels }) {
+		// Return an AudioDecoder
+	},
+};
+
+client.call.setCodecFactory(myOpusCodecs);
+```
+
+## Wire format
+
+LINE Android calls run standard protocols:
+
+| Layer | Spec |
+|---|---|
+| Signaling | SIP/2.0 over UDP, pjsip-shaped |
+| Auth | HTTP Digest, `CallRoute.fromToken` as password |
+| SDP | RFC 4566, `m=audio P RTP/SAVP 96`, Opus 48 kHz/2 ch |
+| Key mgmt | MIKEY-PKE (RFC 3830 §6.1), peer key = `CallRoute.stnpk` |
+| Media | SRTP `AES_CM_128_HMAC_SHA1_80` (RFC 3711) |
+| Codec | Opus only on the wire |
+
+`AndromedaTransport` implements all of this. Use SDES (`a=crypto:`) by
+default; when `CallRoute.stnpk` is set the offer switches to MIKEY-PKE.

--- a/packages/linejs/client/features/call/andromeda.test.ts
+++ b/packages/linejs/client/features/call/andromeda.test.ts
@@ -66,7 +66,8 @@ Deno.test("AndromedaTransport.register: 401 → digest → 200 against mock cscf
 	try {
 		await t.connect({
 			route: {
-				cscf: { host: mock.host, port: mock.port } as never,
+				voipAddress: mock.host,
+				voipUdpPort: mock.port,
 				fromToken: "secret-pw",
 			} as never,
 		});
@@ -179,8 +180,8 @@ Deno.test("AndromedaTransport.invite: REGISTER + INVITE + ACK against mock UAS",
 	try {
 		await t.connect({
 			route: {
-				cscf: { host: mock.host, port: mock.port } as never,
-				mix: { host: mock.host, port: mock.port } as never,
+				voipAddress: mock.host,
+				voipUdpPort: mock.port,
 				fromToken: "secret-pw",
 			} as never,
 		});
@@ -197,7 +198,7 @@ Deno.test("AndromedaTransport.invite: REGISTER + INVITE + ACK against mock UAS",
 	}
 });
 
-Deno.test("AndromedaTransport.register: throws on missing cscf", async () => {
+Deno.test("AndromedaTransport.register: throws on missing voipAddress", async () => {
 	const t = new AndromedaTransport({ localMid: "u-test-mid" });
 	let err: unknown;
 	try {
@@ -207,5 +208,5 @@ Deno.test("AndromedaTransport.register: throws on missing cscf", async () => {
 	}
 	await t.close().catch(() => {});
 	assert(err instanceof Error);
-	assertEquals(/no cscf/.test((err as Error).message), true);
+	assertEquals(/no voipAddress/.test((err as Error).message), true);
 });

--- a/packages/linejs/client/features/call/andromeda.ts
+++ b/packages/linejs/client/features/call/andromeda.ts
@@ -2,6 +2,7 @@
 // Uses node:dgram for UDP (works in Node and Deno without flags).
 
 import { Buffer } from "node:buffer";
+import type { Socket as DgramSocket } from "node:dgram";
 import type * as LINETypes from "@evex/linejs-types";
 import type { CallTransport } from "./session.ts";
 import {
@@ -37,11 +38,40 @@ export interface AndromedaTransportOpts {
 	timeoutMs?: number;
 }
 
-interface UdpSocket {
-	send(data: Uint8Array, port: number, host: string, cb: (e?: Error) => void): void;
-	on(ev: "message", h: (msg: Buffer, rinfo: { address: string; port: number }) => void): void;
-	close(cb?: () => void): void;
-	bind(opts: { address?: string; port?: number }, cb?: () => void): void;
+type UdpSocket = DgramSocket;
+
+/** Endpoint extracted from a CallRoute. SIP signaling + media live on
+ *  the same UDP host:port for LINE; SRTP packets flow back over RTP-
+ *  established socket pairs after the SDP answer. */
+interface CallRouteEndpoint {
+	host: string;
+	port: number;
+	tcpPort?: number;
+	host6?: string;
+	fromToken: string;
+	stnpk?: Uint8Array;
+}
+
+/** Decode a base64 string to Uint8Array. */
+function b64decode(s: string): Uint8Array {
+	const bin = atob(s);
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}
+
+/** Resolve the SIP/SRTP endpoint + credentials from a CallRoute. */
+function routeEndpoint(r: LINETypes.CallRoute): CallRouteEndpoint {
+	if (!r.voipAddress) throw new Error("CallRoute: no voipAddress");
+	if (!r.voipUdpPort) throw new Error("CallRoute: no voipUdpPort");
+	return {
+		host: r.voipAddress,
+		port: r.voipUdpPort,
+		tcpPort: r.voipTcpPort,
+		host6: r.voipAddress6 || undefined,
+		fromToken: r.fromToken,
+		stnpk: r.stnpk ? b64decode(r.stnpk) : undefined,
+	};
 }
 
 export class AndromedaTransport implements CallTransport {
@@ -74,7 +104,7 @@ export class AndromedaTransport implements CallTransport {
 	async connect(opts: { route: LINETypes.CallRoute }): Promise<void> {
 		this.#route = opts.route;
 		const dgram = await import("node:dgram");
-		const sock = dgram.createSocket("udp4") as unknown as UdpSocket;
+		const sock: UdpSocket = dgram.createSocket("udp4");
 		this.#sock = sock;
 		await new Promise<void>((res) => sock.bind({ address: "0.0.0.0", port: 0 }, () => res()));
 		sock.on("message", (buf, rinfo) => {
@@ -143,25 +173,21 @@ export class AndromedaTransport implements CallTransport {
 
 	/** REGISTER against cscf. Returns final SIP status (200 = registered). */
 	async register(): Promise<number> {
-		const route = this.#route!;
-		const cscf = (route as { cscf?: { host?: string; port?: number } }).cscf;
-		const token = (route as { fromToken?: string }).fromToken ?? "";
-		if (!cscf?.host || !cscf?.port) {
-			throw new Error("AndromedaTransport.register: no cscf in CallRoute");
-		}
-		const target = `sip:${cscf.host}`;
+		const ep = routeEndpoint(this.#route!);
+		const token = ep.fromToken;
+		const target = `sip:${ep.host}`;
 		const callId = this.#callId ?? randomCallId(this.#opts.localMid);
 		const fromTag = this.#sipFromTag ?? newBranch().slice(7, 15);
 		this.#callId = callId;
 		this.#sipFromTag = fromTag;
-		this.#sipFrom = `<sip:${this.#opts.localMid}@${cscf.host}>`;
+		this.#sipFrom = `<sip:${this.#opts.localMid}@${ep.host}>`;
 		const ua = this.#opts.userAgent ?? "Line/26.6.2";
 
 		const baseHeaders = (cseq: number, auth?: string): Record<string, string> => ({
 			"Via": `SIP/2.0/UDP ${this.#opts.localMid}.invalid;branch=${newBranch()};rport`,
 			"Max-Forwards": "70",
-			"From": `<sip:${this.#opts.localMid}@${cscf.host}>;tag=${fromTag}`,
-			"To": `<sip:${this.#opts.localMid}@${cscf.host}>`,
+			"From": `<sip:${this.#opts.localMid}@${ep.host}>;tag=${fromTag}`,
+			"To": `<sip:${this.#opts.localMid}@${ep.host}>`,
 			"Call-ID": callId,
 			"CSeq": `${cseq} REGISTER`,
 			"User-Agent": ua,
@@ -171,7 +197,7 @@ export class AndromedaTransport implements CallTransport {
 			...(auth ? { "Authorization": auth } : {}),
 		});
 
-		const dst = { host: cscf.host, port: cscf.port };
+		const dst = { host: ep.host, port: ep.port };
 		this.#cseq++;
 		await this.#sendTo(dst, {
 			startLine: `REGISTER ${target} SIP/2.0`,
@@ -190,7 +216,7 @@ export class AndromedaTransport implements CallTransport {
 		const auth = await digestResponse({
 			username: this.#opts.localMid,
 			password: token,
-			realm: d.realm ?? cscf.host,
+			realm: d.realm ?? ep.host,
 			nonce: d.nonce ?? "",
 			uri: target,
 			method: "REGISTER",
@@ -224,10 +250,7 @@ export class AndromedaTransport implements CallTransport {
 		 *  call; without it the answer's KEMAC is opaque. */
 		decryptKey?: Uint8Array;
 	}): Promise<{ status: number; remoteKey: Uint8Array; mix: { host: string; port: number } }> {
-		const route = this.#route!;
-		const cscf = (route as { cscf?: { host: string; port: number } }).cscf!;
-		const mix = (route as { mix?: { host: string; port: number } }).mix ?? cscf;
-		if (!mix.host || !mix.port) throw new Error("invite: no mix host/port in CallRoute");
+		const ep = routeEndpoint(this.#route!);
 
 		// Generate local SRTP key (16-byte key + 14-byte salt = 30 bytes)
 		const localKey = new Uint8Array(SRTP_KEYING_LEN);
@@ -236,7 +259,7 @@ export class AndromedaTransport implements CallTransport {
 
 		const localHost = opts.localHost ?? "0.0.0.0";
 		const localPort = opts.localPort ?? 0;
-		const stnpk = (route as unknown as { stnpk?: Uint8Array }).stnpk;
+		const stnpk = ep.stnpk;
 		const offerSdp = stnpk
 			? buildAudioOfferMikey({
 				host: localHost,
@@ -258,10 +281,10 @@ export class AndromedaTransport implements CallTransport {
 				username: this.#opts.localMid,
 			});
 
-		const target = `sip:${opts.to}@${cscf.host}`;
+		const target = `sip:${opts.to}@${ep.host}`;
 		this.#cseq++;
 		const ua = this.#opts.userAgent ?? "Line/26.6.2";
-		await this.#sendTo({ host: cscf.host, port: cscf.port }, {
+		await this.#sendTo({ host: ep.host, port: ep.port }, {
 			startLine: `INVITE ${target} SIP/2.0`,
 			headers: {
 				"Via": `SIP/2.0/UDP ${this.#opts.localMid}.invalid;branch=${newBranch()};rport`,
@@ -314,9 +337,12 @@ export class AndromedaTransport implements CallTransport {
 		this.#remoteKey = remoteKey;
 		this.#srtpSend = await deriveSrtpContext(localKey);
 		this.#srtpRecv = await deriveSrtpContext(remoteKey);
+		// SRTP flows to the SDP-answer's connection address + media port.
+		const answerC = audio.c ?? answer.c ?? "";
+		const ansHost = answerC.split(/\s+/)[2] ?? ep.host;
 		this.#rtp = {
-			host: mix.host,
-			port: mix.port,
+			host: ansHost,
+			port: audio.port || ep.port,
 			ssrc: Math.floor(Math.random() * 0xffffffff) >>> 0,
 			seq: Math.floor(Math.random() * 0x10000),
 			timestamp: Math.floor(Math.random() * 0x10000),
@@ -324,7 +350,7 @@ export class AndromedaTransport implements CallTransport {
 
 		// ACK to complete the 3-way handshake
 		this.#cseq++;
-		await this.#sendTo({ host: cscf.host, port: cscf.port }, {
+		await this.#sendTo({ host: ep.host, port: ep.port }, {
 			startLine: `ACK ${target} SIP/2.0`,
 			headers: {
 				"Via": `SIP/2.0/UDP ${this.#opts.localMid}.invalid;branch=${newBranch()};rport`,
@@ -339,7 +365,11 @@ export class AndromedaTransport implements CallTransport {
 			body: "",
 		});
 
-		return { status: finalStatus, remoteKey, mix: { host: mix.host, port: mix.port } };
+		return {
+			status: finalStatus,
+			remoteKey,
+			mix: { host: this.#rtp.host, port: this.#rtp.port },
+		};
 	}
 
 	#sendTo(
@@ -365,21 +395,17 @@ async function decryptMikeyKemac(
 	parsed: ReturnType<typeof parseMikey>,
 	pkcs8PrivateKey: Uint8Array,
 ): Promise<Uint8Array> {
-	const spkiBuf = pkcs8PrivateKey.buffer.slice(
-		pkcs8PrivateKey.byteOffset,
-		pkcs8PrivateKey.byteOffset + pkcs8PrivateKey.byteLength,
-	) as ArrayBuffer;
+	if (!parsed.pkeBody) throw new Error("MIKEY answer: missing PKE body");
+	if (!parsed.kemacEncrypted) throw new Error("MIKEY answer: missing KEMAC");
 	const priv = await crypto.subtle.importKey(
 		"pkcs8",
-		spkiBuf,
+		toArrayBuffer(pkcs8PrivateKey),
 		{ name: "RSA-OAEP", hash: "SHA-1" },
 		false,
 		["decrypt"],
 	);
-	const pke = parsed.pkeBody!;
-	const pkeBuf = pke.buffer.slice(pke.byteOffset, pke.byteOffset + pke.byteLength) as ArrayBuffer;
 	const envKey = new Uint8Array(
-		await crypto.subtle.decrypt({ name: "RSA-OAEP" }, priv, pkeBuf),
+		await crypto.subtle.decrypt({ name: "RSA-OAEP" }, priv, toArrayBuffer(parsed.pkeBody)),
 	);
 	// Derive encr_key from envKey, then AES-CTR decrypt the KEMAC body
 	const info = new Uint8Array(8);
@@ -390,7 +416,15 @@ async function decryptMikeyKemac(
 	const encrKey = new Uint8Array(macKey).subarray(0, 16);
 	const iv = new Uint8Array(16);
 	const c = createCipheriv("aes-128-ctr", Buffer.from(encrKey), Buffer.from(iv));
-	const inner = Buffer.concat([c.update(Buffer.from(parsed.kemacEncrypted!)), c.final()]);
+	const inner = Buffer.concat([c.update(Buffer.from(parsed.kemacEncrypted)), c.final()]);
 	// Skip the KEY_DATA payload header (5 bytes) to get the 30-byte TGK
 	return new Uint8Array(inner.subarray(5, 5 + 30));
+}
+
+/** Strict ArrayBuffer slice — avoids the SharedArrayBuffer ambiguity on
+ *  Uint8Array.buffer when calling WebCrypto. */
+function toArrayBuffer(u: Uint8Array): ArrayBuffer {
+	const ab = new ArrayBuffer(u.byteLength);
+	new Uint8Array(ab).set(u);
+	return ab;
 }

--- a/packages/linejs/client/features/call/e2e.test.ts
+++ b/packages/linejs/client/features/call/e2e.test.ts
@@ -1,0 +1,155 @@
+// End-to-end: PCM → codec → SRTP wire → SRTP receive → codec → PCM,
+// using a loopback transport. Proves the audio plumbing carries
+// samples bit-identical without needing a real Opus impl.
+import { assertEquals } from "@std/assert";
+import { CallSession, type CallTransport } from "./session.ts";
+import {
+	type AudioDecoder,
+	type AudioEncoder,
+	bufferSink,
+	bufferSource,
+	type CodecFactory,
+	type PcmFrame,
+} from "./audio.ts";
+import { deriveSrtpContext, SRTP_KEYING_LEN, srtpDecrypt, srtpEncrypt, buildRtp, parseRtp } from "./srtp.ts";
+
+/** Identity codec — encodes a PCM frame to a binary packet that
+ *  encloses the raw samples. */
+function identityCodec(): CodecFactory {
+	return {
+		newEncoder(): AudioEncoder {
+			return {
+				encode(f: PcmFrame): Uint8Array {
+					const buf = new Uint8Array(4 + f.samples.byteLength);
+					new DataView(buf.buffer).setUint32(0, f.samples.length, false);
+					buf.set(new Uint8Array(f.samples.buffer, f.samples.byteOffset, f.samples.byteLength), 4);
+					return buf;
+				},
+			};
+		},
+		newDecoder(): AudioDecoder {
+			return {
+				decode(p: Uint8Array): PcmFrame {
+					const n = new DataView(p.buffer, p.byteOffset, p.byteLength).getUint32(0, false);
+					const samples = new Int16Array(n);
+					new Uint8Array(samples.buffer).set(p.subarray(4, 4 + n * 2));
+					return { samples, sampleRate: 16000, channels: 1 };
+				},
+			};
+		},
+	};
+}
+
+/** A loopback transport that runs sent packets through SRTP encrypt
+ *  then back through SRTP decrypt to itself — exercises the full
+ *  send and receive path. */
+function loopbackTransport(): CallTransport {
+	const keying = new Uint8Array(SRTP_KEYING_LEN);
+	for (let i = 0; i < keying.length; i++) keying[i] = (i + 5) & 0xff;
+	let sendCtx: Awaited<ReturnType<typeof deriveSrtpContext>>;
+	let recvCtx: Awaited<ReturnType<typeof deriveSrtpContext>>;
+	const incoming: Uint8Array[] = [];
+	const waiters: ((b: Uint8Array | null) => void)[] = [];
+	let ssrc = 0xabcdef01;
+	let seq = 0;
+	let timestamp = 0;
+	return {
+		async connect() {
+			sendCtx = await deriveSrtpContext(keying);
+			recvCtx = await deriveSrtpContext(keying);
+		},
+		close() { return Promise.resolve(); },
+		async send(opusPacket: Uint8Array) {
+			const rtp = buildRtp({
+				payloadType: 96,
+				seq: seq++,
+				timestamp: (timestamp += 320),
+				ssrc,
+				payload: opusPacket,
+			});
+			const srtp = await srtpEncrypt(sendCtx, rtp);
+			const rtpDec = await srtpDecrypt(recvCtx, srtp);
+			const payload = parseRtp(rtpDec).payload;
+			const w = waiters.shift();
+			if (w) w(payload);
+			else incoming.push(payload);
+		},
+		async *receive() {
+			while (true) {
+				const p = incoming.length
+					? incoming.shift()!
+					: await new Promise<Uint8Array | null>((r) => waiters.push(r));
+				if (!p) return;
+				yield p;
+			}
+		},
+	};
+}
+
+Deno.test("e2e: PCM → codec → SRTP → loopback → SRTP → codec → PCM (byte-identical)", async () => {
+	const session = new CallSession(
+		{
+			call: {
+				acquireRoute() {
+					return Promise.resolve({
+						voipAddress: "127.0.0.1",
+						voipUdpPort: 9999,
+						fromToken: "x",
+					});
+				},
+			},
+		} as never,
+		{
+			to: "u-peer",
+			transport: loopbackTransport(),
+			codecs: identityCodec(),
+		},
+	);
+	await session.start();
+
+	const samples = new Int16Array(1600);
+	for (let i = 0; i < samples.length; i++) {
+		samples[i] = Math.floor(Math.sin((2 * Math.PI * 440 * i) / 16000) * 10000);
+	}
+
+	const sink = bufferSink();
+	const recvPromise = (async () => {
+		let got = 0;
+		const it = session.received();
+		while (got < samples.length) {
+			let timeoutId: number | undefined;
+			const next = await Promise.race([
+				it.next(),
+				new Promise<{ done: true; value: undefined }>((r) => {
+					timeoutId = setTimeout(
+						() => r({ done: true, value: undefined }),
+						1000,
+					) as unknown as number;
+				}),
+			]);
+			if (timeoutId !== undefined) clearTimeout(timeoutId);
+			if (next.done || !next.value) break;
+			sink.write(next.value);
+			got += next.value.samples.length;
+		}
+	})();
+
+	await session.sendStream(bufferSource({
+		samples,
+		sampleRate: 16000,
+		frameDurationMs: 20,
+	}));
+	await recvPromise;
+	await session.end();
+
+	let total = 0;
+	for (const f of sink.frames) total += f.samples.length;
+	const recovered = new Int16Array(total);
+	let o = 0;
+	for (const f of sink.frames) {
+		recovered.set(f.samples, o);
+		o += f.samples.length;
+	}
+	assertEquals(recovered.length, samples.length);
+	assertEquals(recovered, samples);
+});

--- a/packages/linejs/client/features/call/mikey.test.ts
+++ b/packages/linejs/client/features/call/mikey.test.ts
@@ -75,11 +75,12 @@ Deno.test("MIKEY-PKE: peer can decrypt envelope key with private RSA key", async
 	});
 	const parsed = parseMikey(msg);
 	// Decrypt PKE body with the private key
-	const pke = parsed.pkeBody!;
-	const ab = pke.buffer.slice(pke.byteOffset, pke.byteOffset + pke.byteLength) as ArrayBuffer;
+	const pke = parsed.pkeBody;
+	if (!pke) throw new Error("expected pkeBody");
+	const ab = new ArrayBuffer(pke.byteLength);
+	new Uint8Array(ab).set(pke);
 	const dec = await crypto.subtle.decrypt({ name: "RSA-OAEP" }, kp.priv, ab);
-	const recovered = new Uint8Array(dec);
-	assertEquals(recovered, envKey);
+	assertEquals(new Uint8Array(dec), envKey);
 });
 
 Deno.test("mikeyToBase64 + mikeyFromBase64 round-trip", () => {

--- a/packages/linejs/client/features/call/mikey.ts
+++ b/packages/linejs/client/features/call/mikey.ts
@@ -245,17 +245,26 @@ async function deriveMikeyKey(envKey: Uint8Array, csbId: number, label: number):
 
 /** RSA-OAEP-SHA1 encrypt with a DER-encoded SPKI public key. */
 async function rsaOaepEncrypt(spki: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
-	const spkiBuf = spki.buffer.slice(spki.byteOffset, spki.byteOffset + spki.byteLength) as ArrayBuffer;
 	const key = await crypto.subtle.importKey(
 		"spki",
-		spkiBuf,
+		toArrayBuffer(spki),
 		{ name: "RSA-OAEP", hash: "SHA-1" },
 		false,
 		["encrypt"],
 	);
-	const ptBuf = plaintext.buffer.slice(plaintext.byteOffset, plaintext.byteOffset + plaintext.byteLength) as ArrayBuffer;
-	const ct = await crypto.subtle.encrypt({ name: "RSA-OAEP" }, key, ptBuf);
+	const ct = await crypto.subtle.encrypt(
+		{ name: "RSA-OAEP" },
+		key,
+		toArrayBuffer(plaintext),
+	);
 	return new Uint8Array(ct);
+}
+
+/** Copy a Uint8Array into a fresh ArrayBuffer (avoids SAB ambiguity). */
+function toArrayBuffer(u: Uint8Array): ArrayBuffer {
+	const ab = new ArrayBuffer(u.byteLength);
+	new Uint8Array(ab).set(u);
+	return ab;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Drop as-unknown-as, use real CallRoute fields, add a PCM round-trip e2e test that proves the pipeline byte-identical. 108/108 green.