### PR TITLE
v2.16.0: Opus bundle + live SIP verification

### DIFF
--- a/packages/linejs/client/features/call/mod.ts
+++ b/packages/linejs/client/features/call/mod.ts
@@ -24,6 +24,7 @@ export {
 } from "./audio.ts";
 export { stubTransport } from "./session.ts";
 export { AndromedaTransport, type AndromedaTransportOpts } from "./andromeda.ts";
+export { opusCodecFactory } from "./opus.ts";
 export {
 	buildAudioOffer,
 	buildAudioOfferMikey,

--- a/packages/linejs/client/features/call/opus.test.ts
+++ b/packages/linejs/client/features/call/opus.test.ts
@@ -1,0 +1,44 @@
+import { assert, assertEquals } from "@std/assert";
+import { opusCodecFactory } from "./opus.ts";
+
+Deno.test("opusCodecFactory: encodes + decodes a 20ms 48kHz mono frame", async () => {
+	const factory = await opusCodecFactory();
+	const enc = factory.newEncoder({ sampleRate: 48000, channels: 1 });
+	const dec = factory.newDecoder({ sampleRate: 48000, channels: 1 });
+
+	const pcm = new Int16Array(960); // 20ms @ 48kHz
+	for (let i = 0; i < pcm.length; i++) {
+		pcm[i] = Math.floor(Math.sin((2 * Math.PI * 440 * i) / 48000) * 10000);
+	}
+	const packet = enc.encode({ samples: pcm, sampleRate: 48000, channels: 1 });
+	assert(packet !== null);
+	assert(packet.length > 0, "encoded packet should be non-empty");
+	assert(packet.length < pcm.byteLength, "Opus should compress vs PCM");
+
+	const frame = dec.decode(packet);
+	assert(frame !== null, "decode should yield a frame");
+	assertEquals(frame.sampleRate, 48000);
+	assertEquals(frame.channels, 1);
+	assertEquals(frame.samples.length, 960);
+	// Opus is lossy — verify rough fidelity by comparing RMS, not byte equality
+	let rmsIn = 0, rmsOut = 0;
+	for (let i = 0; i < pcm.length; i++) rmsIn += pcm[i] * pcm[i];
+	for (let i = 0; i < frame.samples.length; i++) rmsOut += frame.samples[i] * frame.samples[i];
+	rmsIn = Math.sqrt(rmsIn / pcm.length);
+	rmsOut = Math.sqrt(rmsOut / frame.samples.length);
+	// RMS within ±30%
+	assert(rmsOut > rmsIn * 0.7 && rmsOut < rmsIn * 1.3,
+		`RMS drift too large: in=${rmsIn} out=${rmsOut}`);
+
+	enc.close?.();
+	dec.close?.();
+});
+
+Deno.test("opusCodecFactory.newEncoder.encode returns null on partial frame", async () => {
+	const factory = await opusCodecFactory();
+	const enc = factory.newEncoder({ sampleRate: 48000, channels: 1 });
+	const partial = new Int16Array(100);
+	const r = enc.encode({ samples: partial, sampleRate: 48000, channels: 1 });
+	assertEquals(r, null);
+	enc.close?.();
+});

--- a/packages/linejs/client/features/call/opus.ts
+++ b/packages/linejs/client/features/call/opus.ts
@@ -1,0 +1,55 @@
+// Opus codec adapter (wraps npm:opusscript WASM).
+// Optional — only imported when client.call.useDefaultOpus() is called.
+import type { AudioDecoder, AudioEncoder, CodecFactory, PcmFrame } from "./audio.ts";
+import { Buffer } from "node:buffer";
+
+interface OpusInstance {
+	encode(pcm: Buffer, sampleCount: number): Buffer;
+	decode(packet: Buffer): Buffer;
+	delete(): void;
+}
+type OpusCtor = new (rate: number, channels: number, app: number) => OpusInstance;
+const OPUS_VOIP = 2048; // OPUS_APPLICATION_VOIP per opus.h
+
+async function loadOpusScript(): Promise<OpusCtor> {
+	const mod = await import("opusscript");
+	const ctor = (mod as { default?: OpusCtor }).default ?? (mod as unknown as OpusCtor);
+	return ctor;
+}
+
+/** Returns a CodecFactory backed by opusscript (WASM Opus).
+ *  Per LINE's wire: 48 kHz / mono / 20-ms frames. */
+export async function opusCodecFactory(): Promise<CodecFactory> {
+	const OpusCtor = await loadOpusScript();
+	return {
+		newEncoder({ sampleRate, channels }): AudioEncoder {
+			const enc = new OpusCtor(sampleRate, channels, OPUS_VOIP);
+			const frameSamples = (sampleRate * 20) / 1000;
+			return {
+				encode(f: PcmFrame): Uint8Array | null {
+					if (f.samples.length < frameSamples) return null;
+					const buf = Buffer.from(
+						f.samples.buffer,
+						f.samples.byteOffset,
+						frameSamples * 2,
+					);
+					return new Uint8Array(enc.encode(buf, frameSamples));
+				},
+				close() { enc.delete(); },
+			};
+		},
+		newDecoder({ sampleRate, channels }): AudioDecoder {
+			const dec = new OpusCtor(sampleRate, channels, OPUS_VOIP);
+			return {
+				decode(packet: Uint8Array): PcmFrame {
+					const buf = dec.decode(Buffer.from(packet));
+					const samples = new Int16Array(
+						buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+					);
+					return { samples, sampleRate, channels };
+				},
+				close() { dec.delete(); },
+			};
+		},
+	};
+}

--- a/packages/linejs/deno.json
+++ b/packages/linejs/deno.json
@@ -19,6 +19,7 @@
 		"node-types": "npm:@types/node@latest",
 		"node-int64": "npm:node-int64@^0.4.0",
 		"undici": "npm:undici@^7",
-		"@noble/ciphers": "npm:@noble/ciphers@^2.2"
+		"@noble/ciphers": "npm:@noble/ciphers@^2.2",
+		"opusscript": "npm:opusscript@^0.1.1"
 	}
 }


### PR DESCRIPTION
Bundle opusscript WASM via opusCodecFactory(). Live SIP REGISTER → 401(Digest) → response → 403 round-trip verified against real pjsip on sip.linphone.org.