### PR TITLE
v2.16.1: drop 'linejs' literal from default Call-ID / SDP origin

### DIFF
--- a/packages/linejs/client/features/call/sdp.ts
+++ b/packages/linejs/client/features/call/sdp.ts
@@ -152,7 +152,7 @@ export function buildAudioOfferMikey(opts: {
 	sessionVer?: number;
 }): string {
 	const pt = opts.opusPayloadType ?? 96;
-	const user = opts.username ?? "linejs";
+	const user = opts.username ?? "-";
 	const sid = opts.sessionId ?? Math.floor(Date.now() / 1000);
 	const sver = opts.sessionVer ?? sid;
 	return buildSdp({
@@ -187,7 +187,7 @@ export function buildAudioOffer(opts: {
 	sessionVer?: number;
 }): string {
 	const pt = opts.opusPayloadType ?? 96;
-	const user = opts.username ?? "linejs";
+	const user = opts.username ?? "-";
 	const sid = opts.sessionId ?? Math.floor(Date.now() / 1000);
 	const sver = opts.sessionVer ?? sid;
 	return buildSdp({

--- a/packages/linejs/client/features/call/sip.ts
+++ b/packages/linejs/client/features/call/sip.ts
@@ -92,7 +92,7 @@ export function newBranch(): string {
 	return `z9hG4bK-${Date.now().toString(36)}-${branchCounter}`;
 }
 
-export function randomCallId(host = "linejs"): string {
+export function randomCallId(host = "invalid"): string {
 	const r = Array.from(crypto.getRandomValues(new Uint8Array(8)))
 		.map((b) => b.toString(16).padStart(2, "0")).join("");
 	return `${r}@${host}`;


### PR DESCRIPTION
Hardcoded library name was leaking into wire defaults. Use RFC placeholders instead.