### PR TITLE
[codex] fix docs for current public API

### DIFF
--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -1,10 +1,11 @@
 # Authentication
 
-You can get authenticated with multiple ways.
+You can authenticate with password login, QR login, or an existing auth token.
 
 ## Login
 
-Login is a simple way to get authenticated. LINEJS has 2 ways to login.
+Login helpers return a high-level `Client`. Each helper also needs client init
+options, including the device to emulate.
 
 ### `loginWithPassword`
 
@@ -12,16 +13,18 @@ Here is an example:
 ```ts
 import { loginWithPassword } from "@evex/linejs";
 
-const client = loginWithPassword({
+const client = await loginWithPassword({
   email: 'you@example.com', // e-mail address
   password: 'password', // Password
   onPincodeRequest(pincode) {
     console.log('Enter this pincode to your LINE app:', pincode)
   }
+}, {
+  device: "IOSIPAD",
 })
 ```
 
-email, password is required. On first login, you have to enter pincode on mobile app for enable e2ee.
+email and password are required. On first login, you have to enter pincode on mobile app for enable e2ee.
 `onPincodeRequest` can receive a pincode and you can output it with that method to tell users pincode.
 
 ### `loginWithQR`
@@ -29,12 +32,17 @@ email, password is required. On first login, you have to enter pincode on mobile
 In this way, email and password is not needed.
 
 ```ts
-import { loginWithQR } from '@evex/linejs'
+import { loginWithQR } from "@evex/linejs";
 
-const client = loginWithQR({
-  onReceiveQRURL(url) {
-    console.log('Access to this URL:', url)
-  }
+const client = await loginWithQR({
+  onReceiveQRUrl(url) {
+    console.log("Access this URL:", url);
+  },
+  onPincodeRequest(pincode) {
+    console.log("Enter this pincode to your LINE app:", pincode);
+  },
+}, {
+  device: "ANDROIDSECONDARY",
 })
 ```
 
@@ -44,3 +52,10 @@ The function gives an url to read on mobile. You have to create QR with yourself
 
 There is a possibility to banned your account if you tried login many times, so you should use authToken to get authenticated.
 
+```ts
+import { loginWithAuthToken } from "@evex/linejs";
+
+const client = await loginWithAuthToken("YOUR_AUTH_TOKEN", {
+  device: "IOSIPAD",
+});
+```

--- a/docs/docs/methods.md
+++ b/docs/docs/methods.md
@@ -2,11 +2,11 @@
 
 ## Talk Methods
 
-All the functions for TalkService are in `Client.base.talk`.
+All low-level TalkService methods are available on `client.base.talk`.
 
 For example:
 
-```js
+```ts
 await client.base.talk.sendMessage({
     to: "u...",
     text: "Hello, LINEJS!",
@@ -19,11 +19,11 @@ user.
 
 ## Square Methods
 
-All the functions for SquareService are in `Client.square`.
+All low-level SquareService methods are available on `client.base.square`.
 
 For example:
 
-```js
+```ts
 await client.base.square.findSquareByInvitationTicket({
     request: {
         invitationTicket: "INVITATION_TICKET",
@@ -39,11 +39,11 @@ If you just want simple api access or custom event handlers, you can use `BaseCl
 
 For example:
 
-```js
+```ts
 import { BaseClient } from "@evex/linejs/base";
 
 
-const client = new BaseClient({ device: "DESKTOPWIN", version:"..." });
+const client = new BaseClient({ device: "DESKTOPWIN", version: "9.7.0.3556" });
 client.on("pincall", (pin) => {
 });
 

--- a/docs/docs/start-2.md
+++ b/docs/docs/start-2.md
@@ -16,7 +16,7 @@ const client = await loginWithPassword({
   }
 }, { device: "IOSIPAD" })
 
-console.log(await client.base.talk.getProfile());
+console.log(await client.getMyProfile());
 ```
 
 The output will be as follows.
@@ -41,7 +41,8 @@ It is therefore a good idea to use an **AuthToken**.
 
 A temporary token is used for email login.\
 Therefore, after a few days, it will expire and the client will stop running.\
-So, if you want to run the client permanently, you must use v3.
+So, if you want to run the client permanently, persist your storage and reuse an
+auth token instead of repeating email login.
 
 Repeating the email login multiple times is highly discouraged.
 

--- a/docs/docs/utils.md
+++ b/docs/docs/utils.md
@@ -1,83 +1,58 @@
-# Utils of LINEJS
+# Utilities
 
-LINEJS is not only a self-bot.  
-From building internal URIs to building OBS, open chat search, regex for picking emid, ticket, and more.  
-I will explain one by one.  
+Standalone utilities are no longer exported from a separate package subpath.
+Current utilities are exposed through the client or the documented package
+subpaths below.
 
-## LINE_OBS
+## OBS
 
-Utils to retrieve images and videos from obs hash.  
-You can retrieve them as follows  
-
-```ts
-import { LINE_OBS } from "@evex/linejs/utils";
-
-const OBS = new LINE_OBS(); // endpoint is optional
-
-const OBS_IMAGE_URI = OBS.getURI("0hy28TkoGoJh0FLTatCdtZSjt7ezN-Xj8PeFUrfHAvey8pHDUcMEppKXR-eisuFGJObRhheCh6KngqGzY"); // obs hash
-
-const OBS_PROFILE_IAMGE_URI = OBS.getProfileImage("u**********"); // member id (mid)
-
-const OBS_SQUARE_PROFILE_IAMGE_URI = OBS.getSquareMemberImage("p**********"); // square member id (pid)
-
-// and more
-```
-
-All methods can be viewed [here](https://github.com/evex-dev/linejs/blob/main/packages/linejs/utils/obs/index.ts)
-
-## LINE_SCHEME
-
-Utils for constructing a scheme URI for LINE
+OBS helpers are available from the authenticated client's `BaseClient`:
 
 ```ts
-import { LINE_SCHEME } from "@evex/linejs/utils";
+const metadata = await client.base.obs.getMessageObsMetadata({
+  messageId: "MESSAGE_ID",
+});
 
-const SCHEME = new LINE_SCHEME();
-
-const SCHEME_HOME_URI = SCHEME.getHome();
-
-const SCHEME_PROFILE_POPUP_URI = SCHEME.getProfilePopup("u**********");
-
-// and more
+const file = await client.base.obs.downloadMessageData({
+  messageId: "MESSAGE_ID",
+});
 ```
 
-All methods can be viewed [here](https://github.com/evex-dev/linejs/blob/main/packages/linejs/utils/scheme/index.ts)
-
-
-## LINE_REGEX
-
-Utils for extracting tickets and emids from URLs.
+Media upload helpers are available on the same object:
 
 ```ts
-import { LINE_REGEX } from "@evex/linejs/utils";
-
-const REGEX = new LINE_REGEX();
-
-console.log(REGEX.getTicket("Square Invitation https://line.me/ti/g2/*************")); // *************
-
-console.log(REGEX.getEmid(".../emid=*************")); // *************
+const message = await client.base.obs.uploadMediaByE2EE({
+  to: "u...",
+  oType: "image",
+  data: imageFile,
+  filename: "image.png",
+});
 ```
 
-All methods can be viewed [here](https://github.com/evex-dev/linejs/blob/main/packages/linejs/utils/regex/index.ts)
+Implementation details live in
+[`packages/linejs/base/obs/mod.ts`](https://github.com/evex-dev/linejs/blob/main/packages/linejs/base/obs/mod.ts).
 
-## LINE_FUNCTIONS
+## Storage
 
-Utils for connecting to external APIs related to LINE
+Storage helpers are exported from `@evex/linejs/storage`:
 
 ```ts
-import Utils from '@evex/linejs/utils';
+import { FileStorage, MemoryStorage } from "@evex/linejs/storage";
 
-const squareList = await Utils.LINE_FUNCTIONS.searchSquare("Developer", 100);
-
-if (squareList.error === null) {
-    const squareInfo = await Utils.LINE_FUNCTIONS.getSquare(squareList.data.squares[0].square.emid, false, {
-        "x-line-channeltoken": "..."
-    });
-
-    console.log(squareInfo);
-}
+const storage = new FileStorage("./storage.json");
 ```
 
-All methods can be viewed [here](https://github.com/evex-dev/linejs/blob/main/packages/linejs/utils/functions/index.ts)
+Use `FileStorage` when login state, E2EE keys, and request sequence state must
+survive process restarts. Use `MemoryStorage` only for short-lived clients.
 
-The next sections will introduce the various methods.
+## Base Helpers
+
+Low-level helpers that are part of the public base package are exported from
+`@evex/linejs/base`:
+
+```ts
+import { BaseClient, continueRequest, InternalError } from "@evex/linejs/base";
+```
+
+The package exports are defined in
+[`packages/linejs/deno.json`](https://github.com/evex-dev/linejs/blob/main/packages/linejs/deno.json).

--- a/packages/linejs/README.md
+++ b/packages/linejs/README.md
@@ -76,10 +76,12 @@ MessageType, etc.) are provided.
 
 ## Provided Packages
 
-- client - (@evex/linejs) or (@evex/linejs/client)
+- client - (@evex/linejs)
   - Client - LINE SelfBot Client
 - base - (@evex/linejs/base)
   - BaseClient - LINE SelfBot API Client
+- call - (@evex/linejs/call)
+  - Call control-plane and media helpers
 - thrift - (@evex/linejs/thrift)
   - Thrift - Thrift read/write
 - storage - (@evex/linejs/storage)


### PR DESCRIPTION
Fixes #188.

## What changed
- Updated authentication examples to match the current async login helpers and init options.
- Reworked the utilities page to remove the obsolete `@evex/linejs/utils` entrypoint and point to the current public surfaces.
- Corrected method examples and package README references that were stale.

## Validation
- `deno task docs:build`
- markdown link/path checks against local files and GitHub blob targets