### PR TITLE
[codex] fix Android login endpoint and docs link

### DIFF
--- a/docs/docs/message-event.md
+++ b/docs/docs/message-event.md
@@ -5,7 +5,7 @@ The atmosphere is becoming more and more like a bot!
 
 :::warning
 Note, however, that to receive the group's message, the decrypt key
-in `FileStorage` or so on, as described in [Start 2](/docs/start-2). 
+in `FileStorage` or so on, as described in [Start 2](./start-2.md).
 :::
 
 First, let's create a bot that only receives “!ping” and returns “pong!”.

--- a/packages/linejs/base/login/mod.test.ts
+++ b/packages/linejs/base/login/mod.test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "@std/assert";
+import { registrationAuthEndpoint } from "./mod.ts";
+
+Deno.test("registration auth endpoint uses v4 for Android devices", () => {
+	assertEquals(registrationAuthEndpoint("ANDROID"), "/api/v4p/rs");
+	assertEquals(registrationAuthEndpoint("ANDROIDSECONDARY"), "/api/v4p/rs");
+});
+
+Deno.test("registration auth endpoint keeps v3 for existing desktop and iOS logins", () => {
+	assertEquals(registrationAuthEndpoint("DESKTOPWIN"), "/api/v3p/rs");
+	assertEquals(registrationAuthEndpoint("DESKTOPMAC"), "/api/v3p/rs");
+	assertEquals(registrationAuthEndpoint("IOS"), "/api/v3p/rs");
+	assertEquals(registrationAuthEndpoint("IOSIPAD"), "/api/v3p/rs");
+});

--- a/packages/linejs/base/login/mod.ts
+++ b/packages/linejs/base/login/mod.ts
@@ -18,6 +18,14 @@ export type LoginOption = PasswordLoginOption | QrCodeLoginOption | {
 	qr?: undefined;
 };
 
+export function registrationAuthEndpoint(
+	device: Device,
+): "/api/v3p/rs" | "/api/v4p/rs" {
+	return device === "ANDROID" || device === "ANDROIDSECONDARY"
+		? "/api/v4p/rs"
+		: "/api/v3p/rs";
+}
+
 interface LoginVer {
 	loginV2: LooseType;
 	loginZ: LINETypes.LoginResult;
@@ -664,7 +672,7 @@ export class Login {
 			methodName,
 			3,
 			methodName === "loginZ" ? "LoginResult" : false,
-			"/api/v3p/rs",
+			registrationAuthEndpoint(this.client.device),
 		);
 	}
 
@@ -892,7 +900,7 @@ export class Login {
 			"confirmE2EELogin",
 			3,
 			false,
-			"/api/v3p/rs",
+			registrationAuthEndpoint(this.client.device),
 		);
 	}
 

--- a/packages/linejs/base/request/mod.ts
+++ b/packages/linejs/base/request/mod.ts
@@ -45,6 +45,7 @@ export class RequestClient {
 		"/SQ1": "SquareException",
 		"/LIFF1": "LiffException",
 		"/api/v3p/rs": "TalkException",
+		"/api/v4p/rs": "TalkException",
 		"/api/v3/TalkService.do": "TalkException",
 	};
 


### PR DESCRIPTION
Fixes #190.
Fixes #191.

## What changed
- Route Android and Android secondary registration auth calls through `/api/v4p/rs`, matching the current Android login endpoint instead of `/api/v3p/rs`.
- Add `/api/v4p/rs` exception parsing so LINE errors are decoded consistently.
- Change the Start 2 docs link in `message-event.md` to a relative `.md` path that works on GitHub as well as VitePress.

## Validation
- `deno test --allow-env packages/linejs/base/login/mod.test.ts packages/linejs/client/login.test.ts`
- `deno task docs:build`
- markdown local link check