### PR TITLE
fix(thrift): serialize bigint I64 fields as hex to avoid node-int64 corruption (MESSAGE_NOT_FOUND)

### DIFF
--- a/packages/linejs/base/thrift/readwrite/write.test.ts
+++ b/packages/linejs/base/thrift/readwrite/write.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "@std/assert";
+import { writeStruct, writeThrift } from "./write.ts";
+import { readThrift } from "./read.ts";
+import { type NestedArray, Protocols } from "./declares.ts";
+
+// Thrift type id for I64.
+const I64 = 10;
+
+const hex = (data: Uint8Array): string =>
+	Array.from(data).map((b) => b.toString(16).padStart(2, "0")).join("");
+
+const i64Field = (fid: number, value: bigint): NestedArray =>
+	[[I64, fid, value]] as NestedArray;
+
+// Regression for #193: bigint I64 fields (e.g. a message ID in talk.react)
+// were passed to node-int64 as a decimal string, which the library parses as
+// hex, silently corrupting the value and making LINE return MESSAGE_NOT_FOUND.
+Deno.test("writeThrift round-trips a large bigint I64 without corruption", () => {
+	// 618946633287860670 > Number.MAX_SAFE_INTEGER, taken straight from #193.
+	const messageId = 618946633287860670n;
+	for (const protocol of [Protocols[3], Protocols[4]]) {
+		const bytes = writeThrift(i64Field(1, messageId), "react", protocol);
+		const parsed = readThrift(bytes, protocol);
+		assertEquals(parsed.data[1], messageId);
+	}
+});
+
+Deno.test("writeStruct encodes the exact 64-bit big-endian I64 octets", () => {
+	// Binary protocol writes the field header (0a=I64, 0001=fid) followed by
+	// the raw 8 bytes and a trailing field stop (00). The corrupt decimal-as-hex
+	// path produced different bytes, so this pins the correct wire encoding.
+	const bytes = writeStruct(i64Field(1, 618946633287860670n), Protocols[3]);
+	assertEquals(hex(bytes), "0a0001" + "0896f0af040c01be" + "00");
+});
+
+Deno.test("writeStruct encodes negative I64 as two's complement", () => {
+	// asUintN(64) keeps negative I64 values correct (full 0xff.. byte fill)
+	// rather than zero-extending the low 32 bits.
+	const bytes = writeStruct(i64Field(1, -5n), Protocols[3]);
+	assertEquals(hex(bytes), "0a0001" + "fffffffffffffffb" + "00");
+});
+
+Deno.test("writeThrift round-trips a small bigint I64", () => {
+	// Values within Number.MAX_SAFE_INTEGER come back as a number on read.
+	const bytes = writeThrift(i64Field(1, 5n), "x", Protocols[4]);
+	const parsed = readThrift(bytes, Protocols[4]);
+	assertEquals(parsed.data[1], 5);
+});

--- a/packages/linejs/base/thrift/readwrite/write.ts
+++ b/packages/linejs/base/thrift/readwrite/write.ts
@@ -136,7 +136,17 @@ function writeValue(
 		case Thrift.Type.I64:
 			if (typeof val === "bigint") {
 				output.writeFieldBegin("", Thrift.Type.I64, fid);
-				output.writeI64(new Int64(val.toString()));
+				// node-int64 parses a bare string argument as hex, so passing
+				// `val.toString()` (decimal) silently corrupts the value, e.g.
+				// 618946633287860670n -> "8946633287860670" on the wire, which
+				// makes the LINE server reject message IDs (MESSAGE_NOT_FOUND).
+				// Encode the full 64-bit two's-complement value as a padded hex
+				// string instead; `asUintN` keeps negative I64 values correct.
+				output.writeI64(
+					new Int64(
+						"0x" + BigInt.asUintN(64, val).toString(16).padStart(16, "0"),
+					),
+				);
 				output.writeFieldEnd();
 			} else if (typeof val !== "number") {
 				throw new TypeError(`ftype=${ftype}: value is not number`);


### PR DESCRIPTION
## Summary

Fixes #193.

bigint `I64` fields (e.g. a message ID passed to `talk.react()`) were serialized incorrectly by the Thrift writer. The value was handed to the `node-int64` constructor as a **decimal** string via `val.toString()`, but `node-int64` interprets a bare string argument as **hex**. A message ID like `618946633287860670n` was therefore truncated to a completely different value on the wire, and the LINE server rejected it with `MESSAGE_NOT_FOUND` / `NO_MESSAGE`.

## Fix

`packages/linejs/base/thrift/readwrite/write.ts`

```diff
-output.writeI64(new Int64(val.toString()));
+output.writeI64(
+	new Int64("0x" + BigInt.asUintN(64, val).toString(16).padStart(16, "0")),
+);
```

This builds a `0x`-prefixed, zero-padded 16-char hex string, which `node-int64` parses correctly. Using `BigInt.asUintN(64, val)` (rather than the plain `"0x" + val.toString(16)` from the issue) additionally keeps **negative** `I64` values correct by emitting their full two's-complement bytes instead of zero-extending the low 32 bits.

| value | before (decimal→hex misparse) | after |
| --- | --- | --- |
| `618946633287860670n` | `8946633287860670` ❌ | `0896f0af040c01be` ✅ |
| `-5n` | — | `fffffffffffffffb` ✅ |

## Tests

Adds `packages/linejs/base/thrift/readwrite/write.test.ts`:
- round-trips the issue's exact `> Number.MAX_SAFE_INTEGER` message ID through `writeThrift`/`readThrift` (binary + compact protocols),
- pins the exact 64-bit big-endian wire octets,
- covers negative (two's-complement) and small bigint values.

```
deno test -A packages/linejs/base/thrift/readwrite/write.test.ts   # 4 passed
deno publish --dry-run   # linejs + types: Success
```

Co-authored-by: [As]ReMix <remixasoom@gmail.com>
