### PR TITLE
fix(call): handle non-standard mid-call cc messages to prevent T103 timeout

### DIFF
--- a/packages/linejs/client/features/call/planet/schema.ts
+++ b/packages/linejs/client/features/call/planet/schema.ts
@@ -1194,6 +1194,25 @@ export function packPlanetScMsgKaReq(inner: Uint8Array): Uint8Array {
 	return finalize(b);
 }
 
+// ─── cc_upd_rsp (mid-call quality report / keepalive) ───────────────────
+
+/**
+ * Pack a flat-format UPD_RSP message.  The relay sends a flood of cc
+ * messages with `{ 1:16, 2:<seq>, 3:300, 4:<blob> }` after `conn_req`.
+ * linejs must echo back an equivalent to avoid T103.
+ *
+ * The flat format bypasses the normal cc_msg oneof wrapper — it is NOT
+ * `wrapCcMsg(CC_MSG.UPD_RSP, ...)`, but a top-level protobuf placed
+ * directly in field 3 (cc) of the outer planet_msg.
+ */
+export function packCcUpdRsp(seq: bigint, intervalMs = 300): Uint8Array {
+	const b: Buf = { bytes: [] };
+	emitUint32(b, 1, CC_MSG.UPD_RSP);
+	emitUint64(b, 2, seq);
+	emitUint32(b, 3, intervalMs);
+	return finalize(b);
+}
+
 // ─── handshake helper — extract rmt_nonce from incoming msg ─────────────
 
 /** Extract the loc_nonce (field 6) from a decrypted incoming planet_msg.
@@ -1348,6 +1367,8 @@ export interface DecodedPlanetCcMsg {
 	bodyTag?: number;
 	bodyName?: string;
 	bodyBytes?: Uint8Array;
+	/** Raw decoded fields for non-standard (flat) cc messages. */
+	rawFields?: DecodedField[];
 }
 
 export interface DecodedPlanetMcMsg {
@@ -1385,6 +1406,15 @@ export function decodePlanetCcMsg(bytes: Uint8Array): DecodedPlanetCcMsg {
 			decoded.bodyTag = oneof.tag;
 			decoded.bodyName = CC_MSG_NAMES[oneof.tag] ?? `cc_msg_${oneof.tag}`;
 			decoded.bodyBytes = oneof.value;
+		}
+	}
+	if (!decoded.bodyTag && !hdrBytes && !body && fields.length > 0) {
+		const typeVal = asNumberField(fields, 1);
+		if (typeVal !== undefined) {
+			decoded.bodyTag = typeVal;
+			decoded.bodyName = CC_MSG_NAMES[typeVal] ??
+				`cc_flat_${typeVal}`;
+			decoded.rawFields = fields;
 		}
 	}
 	return decoded;

--- a/packages/linejs/client/features/call/planet/transport.ts
+++ b/packages/linejs/client/features/call/planet/transport.ts
@@ -65,6 +65,7 @@ import {
 	packCcParticipateReq,
 	packCcRelReq,
 	packCcSetupReq,
+	packCcUpdRsp,
 	packKeepaliveReq,
 	packMcDataReq,
 	packMcDataRsp,
@@ -1274,6 +1275,9 @@ export class PlanetTransport implements CallTransport {
 						},
 					).catch(() => {});
 				}
+				if (msg.cc?.rawFields && msg.cc.bodyTag === CC_MSG.UPD_RSP) {
+					void this.#handleFlatCcUpd(msg.cc.rawFields).catch(() => {});
+				}
 			} catch {
 				// Keep the raw reply flowing even if a newer message type is unknown.
 			}
@@ -2308,6 +2312,53 @@ export class PlanetTransport implements CallTransport {
 		);
 	}
 
+	async #handleFlatCcUpd(rawFields: DecodedField[]): Promise<void> {
+		const seq = rawFields.find((f) => f.tag === 2)?.value;
+		const seqBig = typeof seq === "bigint" ? seq : 0n;
+		const interval = fieldNumber(rawFields, 3) ?? 300;
+		if (!this.#updRspActive) {
+			this.#updRspActive = true;
+			this.#updRspIntervalMs = interval;
+			this.#startCcUpdTimer();
+		}
+		this.#lastUpdSeq = seqBig;
+	}
+
+	#updRspActive = false;
+	#updRspIntervalMs = 300;
+	#lastUpdSeq = 0n;
+	#ccUpdTimer: ReturnType<typeof setTimeout> | undefined;
+	#ccUpdSeq = 0n;
+
+	#startCcUpdTimer() {
+		this.#clearCcUpdTimer();
+		const tick = () => {
+			if (this.#closed) return;
+			void this.#sendCcUpdRsp().catch(() => {}).finally(() => {
+				if (!this.#closed && this.#updRspActive) {
+					this.#ccUpdTimer = setTimeout(tick, this.#updRspIntervalMs);
+				}
+			});
+		};
+		this.#ccUpdTimer = setTimeout(tick, this.#updRspIntervalMs);
+	}
+
+	#clearCcUpdTimer() {
+		if (this.#ccUpdTimer !== undefined) {
+			clearTimeout(this.#ccUpdTimer);
+			this.#ccUpdTimer = undefined;
+		}
+	}
+
+	async #sendCcUpdRsp(): Promise<void> {
+		this.#ccUpdSeq++;
+		const updBytes = packCcUpdRsp(this.#ccUpdSeq, this.#updRspIntervalMs);
+		await this.#sendEnvelope(
+			{ kind: "cc", data: updBytes },
+			{ msgId: ccMsgId(CC_MSG.UPD_RSP) },
+		);
+	}
+
 	#clearKeepalive() {
 		if (this.#keepaliveTimer !== undefined) {
 			clearTimeout(this.#keepaliveTimer);
@@ -2347,6 +2398,7 @@ export class PlanetTransport implements CallTransport {
 	async close(): Promise<void> {
 		this.#closed = true;
 		this.#clearKeepalive();
+		this.#clearCcUpdTimer();
 		try {
 			if (
 				this.#setupSent && this.#route && (this.#sock || this.#opts.wireSend)


### PR DESCRIPTION
## Summary

Addresses #198 (1:1 audio call drops with T103 ~10s after answer).

After `conn_req`/`conn_rsp`, the relay sends a flood of cc messages in a **flat protobuf format** that bypasses the standard `cc_msg` oneof wrapper. These messages were invisible to `decodePlanetCcMsg` (field 1 is a varint, not bytes, so `bodyTag` was never set), and the relay tore down the call with T103 after ~10s of no response.

### What the relay sends (from [#198 comment](https://github.com/evex-dev/linejs/issues/198#issuecomment-4895929541))

**Shape A** (~100+/s, in cc channel):
```
{ 1: 16, 2: <monotonic_seq>, 3: 300, 4: <~500B blob> }
```
Field 1 = 16 matches `CC_MSG.UPD_RSP`. This uses a flat protobuf, NOT the standard `wrapCcMsg` oneof format.

**Shape B** (periodic, in sc channel):
```
{ 1: 0, 2: 500, 3: 16, 4: 16, 5: [{1:<ts>, 2:<ts>}, ...] }
```
RTCP-equivalent media statistics — currently stored as `scBytes` but never processed.

### Changes

- `decodePlanetCcMsg`: fall back to flat-format parsing when standard header+body fields are absent; expose `rawFields` on `DecodedPlanetCcMsg` for downstream handling
- `packCcUpdRsp`: new encoder for flat-format UPD_RSP echo messages
- `PlanetTransport.#handleFlatCcUpd`: detects flat UPD_RSP (bodyTag=16) cc messages and starts a periodic cc-level echo timer matching the relay's interval (default 300ms)
- Timer is cleaned up on `close()`

### ⚠️ Speculative — needs manual testing

This fix is a **best-effort hypothesis** based on the decoded captures in the issue. The exact response format expected by the relay is not confirmed. The approach:
1. Parse the flat cc messages to identify them (this part is solid)
2. Echo back periodic `UPD_RSP` at the relay's interval (speculative — could be wrong format/type)

**To verify**: Run a 1:1 audio call and check if it survives past ~10s without T103. If T103 still fires, the response format or message type needs adjustment.

## Test plan

- [x] `deno check` passes
- [x] All 209 existing tests pass
- [ ] **Manual**: 1:1 audio call must survive past 10s without T103
- [ ] **Manual**: Verify Shape A messages are now logged as `cc_flat_16` / `upd_rsp` instead of `cc:"" ccTag:0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)