### PR TITLE
fix(square): expose continuationToken in fetchSquareChatEvents options

### DIFF
--- a/packages/linejs/base/service/square/mod.ts
+++ b/packages/linejs/base/service/square/mod.ts
@@ -128,6 +128,7 @@ export class SquareService implements BaseService {
 		squareChatMid: string;
 		threadMid?: string;
 		syncToken?: string;
+		continuationToken?: string;
 		limit?: number;
 		direction?: LINETypes.FetchDirection;
 	}): Promise<


### PR DESCRIPTION
## Summary

Adds `continuationToken?: string` to the options type of `fetchSquareChatEvents` in `packages/linejs/base/service/square/mod.ts`.

The thrift serialization layer already supports it — `FetchSquareChatEventsRequest` in `packages/linejs/base/thrift/readwrite/struct.ts` writes `continuationToken` as field 7 — but the wrapper's options type does not expose it, so TypeScript callers cannot pass it without a type cast.

## Why it matters

`continuationToken` is required for paging backwards through square chat history with `direction: BACKWARD`. Observed server behavior (tested with device type `DESKTOPWIN`):

- `BACKWARD` with no continuation token returns 0 events
- Keeping `syncToken` fixed while paging returns the same window repeatedly; updating **both** `syncToken` and `continuationToken` from each response is what advances the paging

Without this field in the type, fetching older square chat messages is impossible from typed code — currently it requires a workaround like:

```ts
await client.base.square.fetchSquareChatEvents({
    squareChatMid,
    syncToken,
    direction: LINETypes.enums.FetchDirection.BACKWARD,
    ...({ continuationToken } as object), // bypass the type check
});
```

Related: #42 (question about fetching previous messages from a square chat).

## Changes

- One line: add `continuationToken?: string` to the options type. No runtime behavior change — the value was already passed through to the thrift struct via the spread into `request`.