### PR TITLE
fix(obs): let uploadObjTalk carry the real audio/video duration instead of hardcoding 1919

### DIFF
--- a/packages/linejs/base/obs/mod.ts
+++ b/packages/linejs/base/obs/mod.ts
@@ -157,6 +157,7 @@ export class LineObs {
 		data: Blob,
 		oid?: string,
 		filename?: string,
+		durationMs?: number,
 	): Promise<{
 		objId: string;
 		objHash: string;
@@ -195,7 +196,10 @@ export class LineObs {
 			param.cat = "original";
 			param.type = "image";
 		} else if (type === "audio" || type === "video") {
-			param.duration = "1919"; // 810
+			// LINE uses this obs param verbatim as the displayed length (it does not
+			// recompute it from the uploaded file), so a caller-supplied real duration
+			// must be honoured; keep the historical value as the fallback.
+			param.duration = (durationMs ?? 1919).toString();
 		}
 		const toType: "talk" | "g2" = to[0] === "m" || to[0] === "t"
 			? "g2"


### PR DESCRIPTION
### Problem

`LineObs.uploadObjTalk` hardcodes the obs `duration` param to `"1919"` for audio and video:

```ts
} else if (type === "audio" || type === "video") {
    param.duration = "1919"; // 810
}
```

LINE does **not** recompute the duration server-side from the uploaded m4a/mp4 — it uses the `duration` obs param verbatim as the length shown in the client. As a result every voice/video message sent through `uploadObjTalk` is displayed as ~1.9s regardless of its real length.

### Evidence

Sending voice messages of 19.5s and 8.47s to an OpenChat, then reading the stored message back:

```
contentMetadata = {"AUDLEN":"1919","DURATION":"1919"}
obs metadata audioM4aDetails = undefined   // the server did not analyse the file
```

Uploading the same 8.47s clip but putting the real duration into the obs `duration` param instead yields:

```
contentMetadata = {"AUDLEN":"8470","DURATION":"8470"}   // correct length
```

### Fix

Add an optional `durationMs` argument to `uploadObjTalk`; keep `1919` as the fallback so existing callers are unaffected.

### Environment

- linejs 3.1.4
- device: DESKTOPWIN
- reproduced against an OpenChat (SquareChat)
