### PR TITLE
fix(relation): serialize add friend requests correctly

### DIFF
--- a/example/relation/addfriend.ts
+++ b/example/relation/addfriend.ts
@@ -1,45 +1,34 @@
 import { BaseClient } from "@evex/linejs/base";
 
 const client = new BaseClient({
-    device: "ANDROIDSECONDARY"
+	device: "ANDROIDSECONDARY",
 });
 
 // by group+groupmid
 await client.relation.addFriendByMid({
-    mid: "uhex",
-    reference: '{"screen":"groupMemberList","spec":"native"}',
-    trackingMetaHint: "chex",
-    trackingMetaType: 4,
-})
-
-
-// by talk+chatmid
-await client.relation.addFriendByMid({
-    mid: "uhex",
-    reference: '{"screen":"talkroom:message","spec":"native"}',
-    trackingMetaHint: "uhex",
-    trackingMetaType: 4,
-})
-
+	mid: "uhex",
+	reference: '{"screen":"groupMemberList","spec":"native"}',
+	trackingMetaHint: "chex",
+	trackingMetaType: 5,
+});
 
 // by LINE ID — searches then adds. Official Accounts include the leading "@"
 await client.relation.addFriendByUserId({
-    userId: "@livecast",
-})
+	userId: "@livecast",
+});
 
 // or resolve the mid yourself
 const contact = await client.relation.findContactBySearchIdOrTicketV3({
-    searchId: "@livecast",
-})
-console.log(contact.mid, contact.displayName)
-
+	searchId: "@livecast",
+});
+console.log(contact.mid, contact.displayName);
 
 // by phone number (E.164, e.g. +<country><number> without a leading 0)
 await client.relation.addFriendByPhone({
-    phone: "+66814298575",
-})
+	phone: "+66814298575",
+});
 
 const byPhone = await client.relation.findContactByPhoneV3({
-    phone: "+66814298575",
-})
-console.log(byPhone.mid, byPhone.displayName)
+	phone: "+66814298575",
+});
+console.log(byPhone.mid, byPhone.displayName);

--- a/packages/linejs/base/service/relation/mod.test.ts
+++ b/packages/linejs/base/service/relation/mod.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals } from "@std/assert";
+import {
+	type NestedArray,
+	Protocols,
+} from "../../thrift/readwrite/declares.ts";
+import { readThrift } from "../../thrift/readwrite/read.ts";
+import { writeThrift } from "../../thrift/readwrite/write.ts";
+import { RelationService } from "./mod.ts";
+
+interface RequestCall {
+	value: unknown;
+	methodName: string;
+	protocol: number;
+	parse: boolean | string;
+	path: string;
+}
+
+function makeStubClient() {
+	const calls: RequestCall[] = [];
+	return {
+		calls,
+		client: {
+			getReqseq: () => Promise.resolve(42),
+			request: {
+				request(
+					value: unknown,
+					methodName: string,
+					protocol: number,
+					parse: boolean | string,
+					path: string,
+				) {
+					calls.push({ value, methodName, protocol, parse, path });
+					if (methodName === "findContactBySearchIdOrTicketV3") {
+						return Promise.resolve({ mid: "u-resolved" });
+					}
+					return Promise.resolve({});
+				},
+			},
+		},
+	};
+}
+
+function decodeAddFriendRequest(value: unknown) {
+	return readThrift(
+		writeThrift(value as NestedArray, "addFriendByMid", Protocols[4]),
+		Protocols[4],
+	).data;
+}
+
+Deno.test("addFriendByMid serializes the RE4 request envelope and tracking metadata", async () => {
+	const stub = makeStubClient();
+	const relation = new RelationService(stub.client as never);
+
+	await relation.addFriendByMid({
+		mid: "u-target",
+		reference: '{"screen":"groupMemberList","spec":"native"}',
+		trackingMetaType: 5,
+		trackingMetaHint: "c-group",
+	});
+
+	assertEquals(
+		stub.calls.map(({ methodName, protocol, parse, path }) => ({
+			methodName,
+			protocol,
+			parse,
+			path,
+		})),
+		[{
+			methodName: "addFriendByMid",
+			protocol: 4,
+			parse: true,
+			path: "/RE4",
+		}],
+	);
+	assertEquals(decodeAddFriendRequest(stub.calls[0]!.value), {
+		1: {
+			1: 42,
+			2: "u-target",
+			3: {
+				1: '{"screen":"groupMemberList","spec":"native"}',
+				2: {
+					5: { 1: "c-group" },
+				},
+			},
+		},
+	});
+});
+
+Deno.test("addFriendByUserId uses bySearchId provenance", async () => {
+	const stub = makeStubClient();
+	const relation = new RelationService(stub.client as never);
+
+	await relation.addFriendByUserId({ userId: "alice" });
+
+	assertEquals(
+		stub.calls.map(({ methodName, protocol, parse, path }) => ({
+			methodName,
+			protocol,
+			parse,
+			path,
+		})),
+		[
+			{
+				methodName: "findContactBySearchIdOrTicketV3",
+				protocol: 4,
+				parse: "Contact",
+				path: "/RE4",
+			},
+			{
+				methodName: "addFriendByMid",
+				protocol: 4,
+				parse: true,
+				path: "/RE4",
+			},
+		],
+	);
+	assertEquals(decodeAddFriendRequest(stub.calls[1]!.value), {
+		1: {
+			1: 42,
+			2: "u-resolved",
+			3: {
+				1: '{"screen":"friendAdd:idSearch","spec":"native"}',
+				2: {
+					3: { 1: "alice" },
+				},
+			},
+		},
+	});
+});

--- a/packages/linejs/base/service/relation/mod.ts
+++ b/packages/linejs/base/service/relation/mod.ts
@@ -4,7 +4,6 @@ import { LINEStruct, type ProtocolKey } from "../../thrift/mod.ts";
 import type * as LINETypes from "@evex/linejs-types";
 import type { BaseClient } from "../../core/mod.ts";
 import type { BaseService } from "../types.ts";
-import type { LooseType } from "@evex/loose-types";
 
 export class RelationService implements BaseService {
 	client: BaseClient;
@@ -102,31 +101,37 @@ export class RelationService implements BaseService {
 		reference?: string;
 		trackingMetaType?: number;
 		trackingMetaHint?: string;
-	}): Promise<LooseType> {
+	}): Promise<LINETypes.addFriendByMid_result["success"]> {
 		const { mid, reference, trackingMetaType, trackingMetaHint } = {
 			trackingMetaType: 5,
 			...options,
 		};
 		return await this.client.request.request(
 			[
-				[8, 1, await this.client.getReqseq()], // seq
-				[11, 2, mid],
 				[
 					12,
-					3,
+					1,
 					[
-						[11, 1, reference],
-						[12, 3, [[12, trackingMetaType, [[
-							11,
-							1,
-							trackingMetaHint,
-						]]]]],
+						[8, 1, await this.client.getReqseq()], // seq
+						[11, 2, mid],
+						[
+							12,
+							3,
+							[
+								[11, 1, reference],
+								[12, 2, [[12, trackingMetaType, [[
+									11,
+									1,
+									trackingMetaHint,
+								]]]]],
+							],
+						],
 					],
 				],
 			],
 			"addFriendByMid",
 			this.protocolType,
-			false,
+			true,
 			this.requestPath,
 		);
 	}
@@ -155,14 +160,14 @@ export class RelationService implements BaseService {
 	 */
 	public async addFriendByUserId(options: {
 		userId: string;
-	}): Promise<LooseType> {
+	}): Promise<LINETypes.addFriendByMid_result["success"]> {
 		const contact = await this.findContactBySearchIdOrTicketV3({
 			searchId: options.userId,
 		});
 		return await this.addFriendByMid({
 			mid: contact.mid,
 			reference: '{"screen":"friendAdd:idSearch","spec":"native"}',
-			trackingMetaType: 2,
+			trackingMetaType: 3,
 			trackingMetaHint: options.userId,
 		});
 	}
@@ -188,7 +193,7 @@ export class RelationService implements BaseService {
 	 */
 	public async addFriendByPhone(options: {
 		phone: string;
-	}): Promise<LooseType> {
+	}): Promise<LINETypes.addFriendByMid_result["success"]> {
 		const contact = await this.findContactByPhoneV3({ phone: options.phone });
 		return await this.addFriendByMid({
 			mid: contact.mid,


### PR DESCRIPTION
## Description

  Fix `RelationService.addFriendByMid` serialization for the RE4 endpoint.

  - Wrap `AddFriendByMidRequest` in the required `addFriendByMid_args.request` field.
  - Serialize `trackingMeta` in `AddFriendTracking` field 2.
  - Use `bySearchId` (union tag 3) for `addFriendByUserId`.
  - Parse the generated `addFriendByMid_result` response.
  - Correct the group-member example and add wire-level regression coverage.

  ## Checklist

  - [x] Run tests (`deno test -A`)
  - [x] Add regression tests