### PR TITLE
docs: persist authToken across sessions + warn about REST Accept header

### DIFF
--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -59,3 +59,49 @@ const client = await loginWithAuthToken("YOUR_AUTH_TOKEN", {
   device: "IOSIPAD",
 });
 ```
+
+### Persisting authToken across sessions
+
+`FileStorage` automatically persists things like `cert`, `refreshToken` and
+`expire`, but **the `authToken` itself is not one of them** — you need to save
+it yourself if you want to reuse it on the next run. LINEJS emits an
+`update:authtoken` event every time the token is issued or refreshed, so the
+recommended pattern is:
+
+```ts
+import {
+  loginWithAuthToken,
+  loginWithPassword,
+} from "@evex/linejs";
+import { FileStorage } from "@evex/linejs/storage";
+
+const storage = new FileStorage("./session.json");
+const TOKEN_KEY = "userAuthToken";
+
+const saved = await storage.get(TOKEN_KEY);
+
+const client = typeof saved === "string" && saved
+  // Prefer authToken login to reduce ban risk.
+  ? await loginWithAuthToken(saved, { device: "IOSIPAD", storage })
+  : await loginWithPassword({
+    email: "you@example.com",
+    password: "password",
+    onPincodeRequest(pin) {
+      console.log("Enter this pincode:", pin);
+    },
+  }, { device: "IOSIPAD", storage });
+
+// Persist token whenever LINEJS issues or refreshes it.
+client.base.on("update:authtoken", async (tok) => {
+  await storage.set(TOKEN_KEY, tok);
+});
+
+// Save the current token immediately in case the event fires before this handler
+// is attached (e.g. right after a fresh password login).
+if (client.base.authToken) {
+  await storage.set(TOKEN_KEY, client.base.authToken);
+}
+```
+
+With this pattern, the first run uses email + password (and PIN) and every
+subsequent run reuses the saved token silently.

--- a/docs/docs/methods.md
+++ b/docs/docs/methods.md
@@ -80,3 +80,30 @@ for await (const operation of polling.listenTalkEvents()) {
 for await (const event of polling.listenSquareEvents()) {
 }
 ```
+
+# Calling LINE REST endpoints directly
+
+Some LINE subsystems (Album/Moa, Timeline REST helpers, ...) speak plain HTTP
+JSON on top of the LEGY proxy rather than Thrift, but LINEJS's default
+`getHeader("GET")` helper is tuned for Thrift and sets
+`accept: application/x-thrift` and `content-type: application/x-thrift`. If you
+call a JSON REST endpoint with those defaults you will get
+`{"code":102001,"message":"一時的なエラーが発生しました。"}` back with HTTP 200.
+
+When you hand-craft a REST request, **override both headers to
+`application/json`**:
+
+```ts
+const headers = {
+  ...client.base.request.getHeader("GET"),
+  accept: "application/json",
+  "content-type": "application/json; charset=UTF-8",
+  "X-Line-ChannelToken": token,
+  "X-Line-Mid": client.base.profile!.mid,
+};
+const res = await client.base.fetch(url, {
+  method: "POST",
+  headers,
+  body: new Uint8Array(),
+});
+```


### PR DESCRIPTION
## Description

Two small documentation additions covering footguns I hit while integrating
LINEJS from Bun/TypeScript. Both were nontrivial to diagnose from the existing
docs.

- **`docs/auth.md`** — new *Persisting authToken across sessions* section
  showing the `update:authtoken` + `FileStorage` pattern.
  `FileStorage` auto-persists `cert`, `refreshToken` and `expire` (per
  `packages/linejs/base/storage/kvTypes.ts`) but **`authToken` is not in the
  known key set**, so users must save it themselves via the
  `update:authtoken` event. Without an example this is easy to miss, and the
  next-run fallback to `loginWithPassword` increases ban risk.

- **`docs/methods.md`** — new *Calling LINE REST endpoints directly* note.
  `client.base.request.getHeader("GET")` returns
  `accept: application/x-thrift`, which causes JSON REST endpoints (Album /
  Moa, parts of Timeline, ...) to reject the request with
  `{"code":102001,"message":"一時的なエラーが発生しました。"}` at HTTP 200. Documents
  the required `accept: application/json` override.

Docs-only, no code or test changes.

## Checklist

- [x] Docs only (no runtime code touched)
- [x] `vitepress build` succeeds (verified locally)