### PR TITLE
feat(talk): add getRecentMessagesV2 for single-call recent-message fetch

### DIFF
--- a/packages/linejs/base/service/talk/mod.ts
+++ b/packages/linejs/base/service/talk/mod.ts
@@ -1643,6 +1643,26 @@ export class TalkService implements BaseService {
 	}
 
 	/**
+	 * Fetches the N most recent messages in a message box.
+	 *
+	 * Single-call convenience for "give me the last N messages", skipping the
+	 * `getMessageBoxes` → `lastDeliveredMessageId` lookup that
+	 * `getPreviousMessagesV2WithRequest` needs. Handy for periodic polling or
+	 * initial-fetch tools.
+	 */
+	async getRecentMessagesV2(
+		...param: Parameters<typeof LINEStruct.getRecentMessagesV2_args>
+	): Promise<LINETypes.getRecentMessagesV2_result["success"]> {
+		return await this.client.request.request(
+			LINEStruct.getRecentMessagesV2_args(...param),
+			"getRecentMessagesV2",
+			this.protocolType,
+			true,
+			this.requestPath,
+		);
+	}
+
+	/**
 	 * @description Gets the server time
 	 */
 	public async getServerTime(): Promise<number> {

--- a/packages/linejs/base/thrift/readwrite/struct.ts
+++ b/packages/linejs/base/thrift/readwrite/struct.ts
@@ -8573,6 +8573,14 @@ export function getPreviousMessagesV2WithRequest_args(
 		[8, 3, Pb1_V7(param.syncReason)],
 	];
 }
+export function getRecentMessagesV2_args(
+	param?: PartialDeep<LINETypes.getRecentMessagesV2_args> | undefined,
+): NestedArray {
+	return typeof param === "undefined" ? [] : [
+		[11, 2, param.messageBoxId],
+		[8, 3, param.messagesCount],
+	];
+}
 export function getProductByVersion_args(
 	param?: PartialDeep<LINETypes.getProductByVersion_args> | undefined,
 ): NestedArray {

--- a/packages/types/line_types.ts
+++ b/packages/types/line_types.ts
@@ -19147,6 +19147,16 @@ export interface getPreviousMessagesV2WithRequest_result {
 	e: TalkException;
 }
 
+export interface getRecentMessagesV2_args {
+	messageBoxId: string;
+	messagesCount: number;
+}
+
+export interface getRecentMessagesV2_result {
+	success: Message[];
+	e: TalkException;
+}
+
 export interface getProductByVersion_args {
 	shopId: string;
 	productId: string;

--- a/packages/types/thrift.ts
+++ b/packages/types/thrift.ts
@@ -33516,6 +33516,30 @@ export const Thrift: LooseType = {
 			"struct": "TalkException",
 		},
 	],
+	"getRecentMessagesV2_args": [
+		{
+			"fid": 2,
+			"name": "messageBoxId",
+			"type": 11,
+		},
+		{
+			"fid": 3,
+			"name": "messagesCount",
+			"type": 8,
+		},
+	],
+	"getRecentMessagesV2_result": [
+		{
+			"fid": 0,
+			"name": "success",
+			"list": "Message",
+		},
+		{
+			"fid": 1,
+			"name": "e",
+			"struct": "TalkException",
+		},
+	],
 	"getProductByVersion_args": [
 		{
 			"fid": 2,


### PR DESCRIPTION
## Description

Adds `TalkService.getRecentMessagesV2({messageBoxId, messagesCount})` — the
direct LINE-server API for "give me the last N messages in this box". CHRLINE
has exposed this since forever and the server still honors it; the struct is
also already declared in `resources/line/chrline.thrift` in this repo, just
never wired through to the runtime.

Today's LINEJS forces callers to first call `getMessageBoxes`, dig out
`lastDeliveredMessageId`, and then call `getPreviousMessagesV2WithRequest`
just to fetch the most recent N messages (this is what `Chat.fetchMessages`
does internally). That extra round-trip is unnecessary for polling loops,
initial-fetch tools, or anywhere the caller only cares about "the latest".

Wire format (`fid 2` string `messageBoxId`, `fid 3` i32 `messagesCount`,
result `list<Message>` at `fid 0`) is verified against a live LINE account:
returns Message objects with the same shape as `getPreviousMessagesV2WithRequest`.

## What changed

- **`packages/types/thrift.ts`** — added `getRecentMessagesV2_args` and
  `_result` entries alongside `getPreviousMessagesV2WithRequest_result`.
- **`packages/types/line_types.ts`** — matching TypeScript interfaces.
- **`packages/linejs/base/thrift/readwrite/struct.ts`** — args factory,
  placed next to `getPreviousMessagesV2WithRequest_args`.
- **`packages/linejs/base/service/talk/mod.ts`** — `async getRecentMessagesV2`
  method following the same `client.request.request(...)` pattern used by
  every other method on the service.

Usage:

```ts
const messages = await client.base.talk.getRecentMessagesV2({
  messageBoxId: "u...",
  messagesCount: 100,
});
```

## Checklist

- [x] Verified against live LINE (returns Message[] matching
      getPreviousMessagesV2WithRequest shape)
- [x] Follows existing TalkService method pattern (LINEStruct factory +
      client.request.request)
- [x] No new tests — the method is a thin wrapper over an existing pattern
      and would only test the wire encoding