### PR TITLE
fix(e2ee): select the key-chain entry matching the requested key id

### DIFF
--- a/packages/linejs/base/e2ee/keychain_selection.test.ts
+++ b/packages/linejs/base/e2ee/keychain_selection.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { selectKeyChainEntry } from "./mod.ts";
+
+/**
+ * Chains observed on a real account are ordered oldest-first and hold every
+ * key ever registered, while `keyId` names the one currently in use.
+ */
+const chain = [
+	{ 2: 5894267, 4: "pub-old", 5: "priv-old" },
+	{ 2: 5952097, 4: "pub-mid", 5: "priv-mid" },
+	{ 2: 5979343, 4: "pub-current", 5: "priv-current" },
+];
+
+Deno.test("selectKeyChainEntry picks the entry naming the requested key", () => {
+	assertEquals(selectKeyChainEntry(chain, 5979343)[4], "pub-current");
+	assertEquals(selectKeyChainEntry(chain, 5952097)[4], "pub-mid");
+});
+
+Deno.test("selectKeyChainEntry compares ids as strings", () => {
+	// `keyId` arrives as a string from the login payload and as a number from
+	// the thrift struct, so both have to resolve to the same entry.
+	assertEquals(selectKeyChainEntry(chain, "5979343")[4], "pub-current");
+});
+
+Deno.test("selectKeyChainEntry falls back to the first entry", () => {
+	// Unknown id, or no id at all: keep the pre-existing behaviour, which is
+	// also correct for a chain that only ever holds one key.
+	assertEquals(selectKeyChainEntry(chain, 111)[4], "pub-old");
+	assertEquals(selectKeyChainEntry(chain)[4], "pub-old");
+	assertEquals(selectKeyChainEntry([chain[0]], 5979343)[4], "pub-old");
+});

--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -16,6 +16,29 @@ interface GroupKey {
 	keyId: number;
 }
 
+/**
+ * Picks the key-chain entry a decoded E2EE key belongs to.
+ *
+ * The chain LINE hands over on QR login holds every key the account has ever
+ * registered, oldest first, while `keyId` names the one currently in use. On
+ * an account that has rotated its key, taking the first entry yields real
+ * key material filed under the wrong id: the pair is internally consistent,
+ * so `derivedPub === pubKey` still passes, but nothing it decrypts will ever
+ * authenticate.
+ *
+ * Falls back to the first entry when no id matches, which is the behaviour
+ * callers had before and is still right for a single-entry chain.
+ */
+export function selectKeyChainEntry(
+	chain: LooseType,
+	keyId?: LooseType,
+): LooseType {
+	if (!Array.isArray(chain)) return chain?.[0];
+	if (keyId === undefined || keyId === null) return chain[0];
+	const wanted = String(keyId);
+	return chain.find((entry) => String(entry?.[2]) === wanted) ?? chain[0];
+}
+
 export class E2EE {
 	readonly client: BaseClient;
 	constructor(client: BaseClient) {
@@ -358,6 +381,7 @@ export class E2EE {
 				publicKey,
 				secret,
 				encryptedKeyChain,
+				keyId,
 			);
 			this.e2eeLog("decodeE2EEKeyV1E2EEKeyInfo", {
 				e2eeKey: {
@@ -418,6 +442,7 @@ export class E2EE {
 		publicKey: Buffer,
 		privateKey: Buffer,
 		encryptedKeyChain: Buffer,
+		keyId?: LooseType,
 	): Buffer[] {
 		this.e2eeLog("decryptKeyChainKeyInfo", {
 			decryptKeyChain: {
@@ -440,9 +465,10 @@ export class E2EE {
 		this.e2eeLog("decryptKeyChainBinKeyInfo", {
 			binkey: keychainData.toString("hex"),
 		});
-		const key = this.client.thrift.readThriftStruct(keychainData)[1];
-		const publicKeyBytes = Buffer.from(key[0][4]);
-		const privateKeyBytes = Buffer.from(key[0][5]);
+		const chain = this.client.thrift.readThriftStruct(keychainData)[1];
+		const entry = selectKeyChainEntry(chain, keyId);
+		const publicKeyBytes = Buffer.from(entry[4]);
+		const privateKeyBytes = Buffer.from(entry[5]);
 		return [privateKeyBytes, publicKeyBytes];
 	}
 


### PR DESCRIPTION
## Symptom

On an account whose E2EE key has been rotated, every message fails to decrypt after a QR login, deterministically:

```
Error: Unsupported state or unable to authenticate data
    at Decipheriv.final
    at E2EE.decryptE2EEMessageV2
    at E2EE.decryptE2EETextMessage
```

This looks like #195, but the cause is upstream of the check that #197 added.

## Cause

`decryptKeyChain` always returns `chain[0]`:

```ts
const key = this.client.thrift.readThriftStruct(keychainData)[1];
const publicKeyBytes = Buffer.from(key[0][4]);
const privateKeyBytes = Buffer.from(key[0][5]);
```

The chain LINE hands over on QR login holds **every key the account has registered**, oldest first, while `decodeE2EEKeyV1` labels the result with `keyId` from the login payload. On a rotated account those disagree.

Decoded chain from a real account:

| chain index | keyId |
|---|---|
| 0 | 5894267 — retired, no longer on the server |
| 1 | 5952097 |
| 2 | **5979343** — current, and the value in `data.keyId` |

The stored key ends up as *5894267's material filed under id 5979343*.

## Why the existing guards miss it

1. `derivedPub === pubKey` passes — the pair taken from the chain is a genuine, internally consistent keypair.
2. `verifyStoredKeyAgainstServer` returns `true` when no registered key carries that id, and 5894267 has been retired, so the loop matches nothing and falls through to `return true`.

So `e2ee:keyMismatch` never fires and the bad key is written to storage.

## Fix

Pass the key id into `decryptKeyChain` and pick the entry that names it, falling back to the first entry when nothing matches — so single-entry chains and callers that omit the id behave exactly as before.

Verified against the account above: the correct private key is now stored, `verifyStoredKeyAgainstServer` reports a match, and messages decrypt in both directions, including ones sent from the phone — i.e. the transferred key is genuinely shared with the primary device, with no need to register a competing key.

## Notes

Selection is extracted into an exported `selectKeyChainEntry` so it can be unit-tested without constructing a valid encrypted chain. `deno test packages/linejs/base/e2ee/` passes (7 tests).

Two adjacent problems found while tracking this down, left out of this PR and filed separately:
- `verifyStoredKeyAgainstServer` returning `true` for an unknown key id makes it a no-op exactly when it matters.
- `registerE2EEKeyPair` sends `keyData` as a base64 string while the read path treats the field as raw bytes; LINE answers `invalid key. spec = 1, keyId = 0, publicKey.size = 44`.