### PR TITLE
fix(thrift): sign-extend negative I64 on read; support bigint/BOOL/BYTE/I16 collection elements

### DIFF
--- a/packages/linejs/base/thrift/readwrite/read.ts
+++ b/packages/linejs/base/thrift/readwrite/read.ts
@@ -36,9 +36,17 @@ function isBinary(bin: Buffer) {
 }
 
 function bigInt(bin: Buffer): number | bigint {
-	const hex = bin.toString("hex");
-	const value = BigInt("0x" + hex);
-	if (value <= BigInt(Number.MAX_SAFE_INTEGER)) {
+	let value = BigInt("0x" + bin.toString("hex"));
+	// I64 is two's-complement; when the sign bit is set the raw hex
+	// interpretation yields 2^64 + value, so subtract it to recover
+	// the negative number the sender wrote.
+	if (bin.length === 8 && bin[0] & 0x80) {
+		value -= BigInt(1) << 64n;
+	}
+	if (
+		value >= BigInt(Number.MIN_SAFE_INTEGER) &&
+		value <= BigInt(Number.MAX_SAFE_INTEGER)
+	) {
 		return Number(value);
 	}
 	return value;
@@ -90,6 +98,10 @@ function readValue(
 		return returnData;
 	} else if (ftype == Thrift.Type.BOOL) {
 		return input.readBool();
+	} else if (ftype == Thrift.Type.BYTE) {
+		return input.readByte();
+	} else if (ftype == Thrift.Type.I16) {
+		return input.readI16();
 	} else if (ftype == Thrift.Type.DOUBLE) {
 		return input.readDouble();
 	} else if (ftype == 16) {

--- a/packages/linejs/base/thrift/readwrite/write.test.ts
+++ b/packages/linejs/base/thrift/readwrite/write.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { writeStruct, writeThrift } from "./write.ts";
-import { readThrift } from "./read.ts";
+import { readThrift, readThriftStruct } from "./read.ts";
 import { type NestedArray, Protocols } from "./declares.ts";
 
 // Thrift type id for I64.
@@ -45,4 +45,54 @@ Deno.test("writeThrift round-trips a small bigint I64", () => {
 	const bytes = writeThrift(i64Field(1, 5n), "x", Protocols[4]);
 	const parsed = readThrift(bytes, Protocols[4]);
 	assertEquals(parsed.data[1], 5);
+});
+
+// Regression: the reader interpreted raw two's-complement octets as an
+// unsigned hex number, so negative I64 values came back as huge positives.
+Deno.test("writeThrift round-trips a negative I64", () => {
+	for (const protocol of [Protocols[3], Protocols[4]]) {
+		const bytes = writeThrift(i64Field(1, -5n), "x", protocol);
+		const parsed = readThrift(bytes, protocol);
+		assertEquals(parsed.data[1], -5);
+	}
+});
+
+// Regression: bigint I64 was only accepted for top-level fields; list/set/map
+// elements went through writeValue_, which rejected them with a TypeError.
+Deno.test("writeStruct encodes bigint I64 inside collections", () => {
+	const bytes = writeStruct(
+		[[15, 1, [10, [618946633287860670n]]]] as NestedArray,
+		Protocols[3],
+	);
+	const parsed = readThriftStruct(bytes, Protocols[3]);
+	assertEquals(parsed[1], [618946633287860670n]);
+});
+
+Deno.test("writeStruct encodes BYTE and I16 fields", () => {
+	// Binary protocol: field header (03/06 + fid) then value bytes.
+	const bytes = writeStruct(
+		[[3, 1, 255], [6, 2, 300], [8, 3, 7]] as NestedArray,
+		Protocols[3],
+	);
+	assertEquals(hex(bytes), "030001ff" + "060002012c" + "08000300000007" + "00");
+});
+
+Deno.test("writeStruct round-trips BYTE and I16 collection elements", () => {
+	const bytes = writeStruct(
+		[[15, 1, [3, [1, 2, 3]]], [14, 2, [6, [300, -1]]]] as NestedArray,
+		Protocols[3],
+	);
+	const parsed = readThriftStruct(bytes, Protocols[3]);
+	assertEquals(parsed[1], [1, 2, 3]);
+	assertEquals(parsed[2], [300, -1]);
+});
+
+Deno.test("writeStruct accepts numeric BOOL fields and elements", () => {
+	const bytes = writeStruct(
+		[[2, 1, 1], [14, 2, [2, [true, 0]]]] as NestedArray,
+		Protocols[3],
+	);
+	const parsed = readThriftStruct(bytes, Protocols[3]);
+	assertEquals(parsed[1], true);
+	assertEquals(parsed[2], [true, false]);
 });

--- a/packages/linejs/base/thrift/readwrite/write.ts
+++ b/packages/linejs/base/thrift/readwrite/write.ts
@@ -124,6 +124,24 @@ function writeValue(
 			}
 			break;
 
+		case Thrift.Type.BYTE:
+			if (typeof val !== "number") {
+				throw new TypeError(`ftype=${ftype}: value is not number`);
+			}
+			output.writeFieldBegin("", Thrift.Type.BYTE, fid);
+			output.writeByte(val);
+			output.writeFieldEnd();
+			break;
+
+		case Thrift.Type.I16:
+			if (typeof val !== "number") {
+				throw new TypeError(`ftype=${ftype}: value is not number`);
+			}
+			output.writeFieldBegin("", Thrift.Type.I16, fid);
+			output.writeI16(val);
+			output.writeFieldEnd();
+			break;
+
 		case Thrift.Type.DOUBLE:
 			if (typeof val !== "number") {
 				throw new TypeError(`ftype=${ftype}: value is not number`);
@@ -232,13 +250,13 @@ function writeValue(
 			}
 			output.writeFieldBegin("", Thrift.Type.LIST, fid);
 			{
-                const arr = val[1] as LooseType[];
-                output.writeListBegin(val[0], arr.length);
-                for (let i = 0, L = arr.length; i < L; i++) {
-                    writeValue_(output, val[0], arr[i]);
-                }
-                output.writeListEnd();
-            }
+				const arr = val[1] as LooseType[];
+				output.writeListBegin(val[0], arr.length);
+				for (let i = 0, L = arr.length; i < L; i++) {
+					writeValue_(output, val[0], arr[i]);
+				}
+				output.writeListEnd();
+			}
 			output.writeFieldEnd();
 			break;
 		case Thrift.Type.SET:
@@ -248,13 +266,13 @@ function writeValue(
 			}
 			output.writeFieldBegin("", Thrift.Type.SET, fid);
 			{
-                const arr = val[1] as LooseType[];
-                output.writeSetBegin(val[0], arr.length);
-                for (let i = 0, L = arr.length; i < L; i++) {
-                    writeValue_(output, val[0], arr[i]);
-                }
-                output.writeSetEnd();
-            }
+				const arr = val[1] as LooseType[];
+				output.writeSetBegin(val[0], arr.length);
+				for (let i = 0, L = arr.length; i < L; i++) {
+					writeValue_(output, val[0], arr[i]);
+				}
+				output.writeSetEnd();
+			}
 			output.writeFieldEnd();
 			break;
 		default:
@@ -300,10 +318,21 @@ function writeValue_(
 			break;
 
 		case Thrift.Type.I64:
-			if (typeof val !== "number") {
+			if (typeof val === "bigint") {
+				// Mirror the field-level encoding: node-int64 parses a bare
+				// string as hex, so pass the full 64-bit two's-complement
+				// value as a padded hex string (`asUintN` keeps negatives
+				// correct).
+				output.writeI64(
+					new Int64(
+						"0x" + BigInt.asUintN(64, val).toString(16).padStart(16, "0"),
+					),
+				);
+			} else if (typeof val !== "number") {
 				throw new TypeError(`ftype=${ftype}: value is not number`);
+			} else {
+				output.writeI64(val);
 			}
-			output.writeI64(val);
 			break;
 
 		case Thrift.Type.I32:
@@ -314,10 +343,24 @@ function writeValue_(
 			break;
 
 		case Thrift.Type.BOOL:
-			if (typeof val !== "boolean") {
+			if (typeof val !== "boolean" && typeof val !== "number") {
 				throw new TypeError(`ftype=${ftype}: value is not boolean`);
 			}
-			output.writeBool(val);
+			output.writeBool(Boolean(val));
+			break;
+
+		case Thrift.Type.BYTE:
+			if (typeof val !== "number") {
+				throw new TypeError(`ftype=${ftype}: value is not number`);
+			}
+			output.writeByte(val);
+			break;
+
+		case Thrift.Type.I16:
+			if (typeof val !== "number") {
+				throw new TypeError(`ftype=${ftype}: value is not number`);
+			}
+			output.writeI16(val);
 			break;
 
 		case Thrift.Type.STRUCT:


### PR DESCRIPTION
## Summary

Four related correctness bugs in the Thrift read/write layer, each verified with a failing round-trip before the fix:

### 1. Negative I64 values decoded as huge positive numbers (`read.ts`)

The reader interpreted raw two's-complement octets as an unsigned hex number:

```ts
const value = BigInt("0x" + bin.toString("hex")); // unsigned!
```

The write side was already fixed for negatives (`asUintN`, pinned by `write.test.ts`: `-5n` → `fffffffffffffffb` on the wire), but a round-trip failed: reading `-5n` back gave `18446744073709551611n`. The reader now sign-extends when the top bit is set.

### 2. bigint I64 rejected inside LIST/SET/MAP elements (`write.ts`)

The #193 fix (bigint-safe Int64 encoding) was only applied to field-level `writeValue`. Collection elements go through `writeValue_`, which threw:

```
writeStruct([[10, 1, 618946633287860670n]], P3);         // ok
writeStruct([[15, 1, [10, [618946633287860670n]]]], P3); // TypeError: ftype=10: value is not number
```

This matters for e.g. message IDs passed as list elements. `writeValue_` now mirrors the field-level encoding.

### 3. BYTE (3) and I16 (6) fields silently dropped / corrupt frames

Both types are declared in `NestedArray` but fell through to `default:` in both writers — no error, no bytes:

- Field level: `[[3, 1, 255]]` produced an empty struct (field vanished silently).
- Element level: `writeListBegin(etype=3, count=3)` was written and then *nothing* per element, producing a structurally corrupt frame that claims 3 elements.
- The reader also skipped both types (`readValue` returned `undefined`).

BYTE/I16 are now written and read properly on both sides.

### 4. BOOL accepted numbers at field level but not element level

`writeValue` accepts `boolean | number`, `writeValue_` required strict `boolean`. Now consistent.

## Testing

- Reproduced every case with a scratch harness before fixing (negative round-trip returned `18446744073709551611n`; bigint element threw; BYTE field absent from wire; BYTE list emitted count=3 with zero elements).
- Added regression tests to `write.test.ts` (5 new tests): negative-I64 round-trip on both protocols, bigint-in-collection encoding, BYTE/I16 field wire hex pin, BYTE/I16 collection round-trip, numeric-BOOL acceptance.
- Full suite: `deno test --allow-all` — 219 passed, 0 failed.
- `deno fmt` / `deno lint` clean on touched files.
