### PR TITLE
fix(e2ee): location message decryption (AAD contentType, isSelf, key pinning)

### DIFF
--- a/packages/linejs/base/e2ee/location_decrypt.test.ts
+++ b/packages/linejs/base/e2ee/location_decrypt.test.ts
@@ -1,0 +1,176 @@
+import { assert, assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { E2EE } from "./mod.ts";
+
+/** Verifies the envelope arguments that reach `decryptE2EEMessageV2` when
+ *  decrypting a LOCATION message: the AAD content type must be the numeric
+ *  enum (15), and the self-key / peer-key selection must follow isSelf.
+ *  We don't mock real GCM crypto — we trap the V2 primitive and record
+ *  what flowed into it (same approach as key_selection.test.ts). */
+function makeE2EE(opts: {
+	keysByKeyId: Record<string | number, { privKey: string; pubKey: string }>;
+	latestKey: { privKey: string; pubKey: string };
+	negotiatedPubKey?: Buffer;
+}) {
+	const byIdLookups: (string | number)[] = [];
+	const localPubKeyLookups: [string, string | number | undefined][] = [];
+	const fakeBase = {
+		profile: { mid: "u-self" },
+		storage: {
+			get(k: string) {
+				const m = k.match(/^e2eeKeys:(.+)$/);
+				if (!m) return Promise.resolve(null);
+				const id = m[1];
+				if (id === "u-self") {
+					return Promise.resolve(JSON.stringify(opts.latestKey));
+				}
+				byIdLookups.push(id);
+				if (opts.keysByKeyId[id]) {
+					return Promise.resolve(JSON.stringify(opts.keysByKeyId[id]));
+				}
+				return Promise.resolve(null);
+			},
+		},
+		talk: {
+			getE2EEPublicKeys() {
+				return Promise.resolve([]);
+			},
+		},
+		getToType() {
+			return 0;
+		},
+		log() {},
+	};
+	const e2ee = new E2EE(fakeBase as never);
+	(e2ee as unknown as {
+		getE2EELocalPublicKey: unknown;
+	}).getE2EELocalPublicKey = (
+		mid: string,
+		keyId: string | number | undefined,
+	) => {
+		localPubKeyLookups.push([mid, keyId]);
+		return Promise.resolve(opts.negotiatedPubKey ?? Buffer.alloc(32));
+	};
+
+	const seen: {
+		contentType: number | undefined;
+		privK: Buffer | null;
+		pubK: unknown;
+	} = { contentType: undefined, privK: null, pubK: null };
+	(e2ee as unknown as {
+		decryptE2EEMessageV2: unknown;
+	}).decryptE2EEMessageV2 = (
+		_to: string,
+		_from: string,
+		_chunks: Buffer[],
+		privK: Buffer,
+		pubK: Buffer,
+		_specVersion: number,
+		contentType: number,
+	) => {
+		seen.privK = privK;
+		seen.pubK = pubK;
+		seen.contentType = contentType;
+		return { location: { latitude: 1 } };
+	};
+
+	return { e2ee, seen, byIdLookups, localPubKeyLookups };
+}
+
+function int4(v: number): Buffer {
+	const b = Buffer.alloc(4);
+	b.writeInt32BE(v, 0);
+	return b;
+}
+
+function makeFakeMessage(opts: {
+	senderKeyId: number;
+	receiverKeyId: number;
+	from: string;
+	to: string;
+}) {
+	return {
+		from: opts.from,
+		to: opts.to,
+		toType: "USER",
+		contentType: "LOCATION",
+		contentMetadata: { e2eeVersion: "2" },
+		chunks: [
+			Buffer.alloc(16),
+			Buffer.alloc(64),
+			Buffer.alloc(12),
+			int4(opts.senderKeyId),
+			int4(opts.receiverKeyId),
+		],
+	} as never;
+}
+
+Deno.test("decryptE2EELocationMessage — received: numeric AAD contentType + peer key selected", async () => {
+	const oldKey = { privKey: "AAAA", pubKey: "BBBB" };
+	const newKey = { privKey: "CCCC", pubKey: "DDDD" };
+	const { e2ee, seen, byIdLookups, localPubKeyLookups } = makeE2EE({
+		keysByKeyId: { "9": oldKey, "11": newKey },
+		latestKey: newKey,
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 9,
+		from: "u-them",
+		to: "u-self",
+	});
+	await e2ee.decryptE2EELocationMessage(msg);
+	// "LOCATION" must be mapped to its numeric enum value (15) for the AAD.
+	assertEquals(seen.contentType, 15);
+	// Received message: pin my key by receiverKeyId=9…
+	assert(byIdLookups.includes("9"), "expected by-keyId lookup for 9");
+	assertEquals(
+		Buffer.from(oldKey.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+	// …and use the *sender's* public key, not mine.
+	assertEquals(localPubKeyLookups, [["u-them", 7]]);
+});
+
+Deno.test("decryptE2EELocationMessage — sent: isSelf derived from from-mid", async () => {
+	const key7 = { privKey: "AAAA", pubKey: "BBBB" };
+	const key11 = { privKey: "CCCC", pubKey: "DDDD" };
+	const { e2ee, seen, byIdLookups, localPubKeyLookups } = makeE2EE({
+		keysByKeyId: { "7": key7, "11": key11 },
+		latestKey: key11,
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 11,
+		from: "u-self", // I sent it
+		to: "u-them",
+	});
+	await e2ee.decryptE2EELocationMessage(msg);
+	assertEquals(seen.contentType, 15);
+	assert(byIdLookups.includes("7"), "expected by-keyId lookup for 7");
+	assertEquals(
+		Buffer.from(key7.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+	// Self-sent: use the recipient's public key with receiverKeyId.
+	assertEquals(localPubKeyLookups, [["u-them", 11]]);
+});
+
+Deno.test("decryptE2EELocationMessage — falls back to latest key on by-id miss", async () => {
+	const latestKey = { privKey: "ZZZZ", pubKey: "YYYY" };
+	const { e2ee, seen, byIdLookups } = makeE2EE({
+		keysByKeyId: {}, // empty by-id store
+		latestKey,
+	});
+	const msg = makeFakeMessage({
+		senderKeyId: 7,
+		receiverKeyId: 9,
+		from: "u-them",
+		to: "u-self",
+	});
+	await e2ee.decryptE2EELocationMessage(msg);
+	assert(byIdLookups.includes("9"));
+	assertEquals(
+		Buffer.from(latestKey.privKey, "base64").toString("base64"),
+		seen.privK!.toString("base64"),
+	);
+});

--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -826,14 +826,23 @@ export class E2EE {
 	}
 	public async decryptE2EELocationMessage(
 		messageObj: Message,
-		isSelf = true,
+		isSelf = false,
 	): Promise<Location> {
 		const _from = messageObj.from;
+		if (_from === this.client.profile?.mid) {
+			isSelf = true;
+		}
 		const to = messageObj.to;
 		const toType = messageObj.toType;
 		const metadata = messageObj.contentMetadata;
 		const specVersion = metadata.e2eeVersion || "2";
-		const contentType = messageObj.contentType;
+		// Incoming messages carry the enum *name* (e.g. "LOCATION") because
+		// rename_thrift maps numeric enums back to strings. The AAD needs the
+		// numeric value (LOCATION = 15) — passing the string through produced
+		// NaN → 0 in getIntBytes, so decryption always failed GCM auth.
+		const contentType = typeof messageObj.contentType === "string"
+			? LINETypes.enums.ContentType[messageObj.contentType]
+			: messageObj.contentType;
 		const chunks = messageObj.chunks.map((chunk) =>
 			typeof chunk === "string" ? Buffer.from(chunk, "utf-8") : chunk
 		);
@@ -843,18 +852,27 @@ export class E2EE {
 		this.e2eeLog("decryptE2EELocationMessageSenderKeyId", senderKeyId);
 		this.e2eeLog("decryptE2EELocationMessageReceiverKeyId", receiverKeyId);
 
-		const selfKey = await this.getE2EESelfKeyData(
-			this.client.profile?.mid as string,
-		);
-		let privK = Buffer.from(selfKey.privKey, "base64");
+		let privK: Buffer;
 		let pubK: LooseType;
 
 		if (toType === LINETypes.enums.MIDType.USER || toType === "USER") {
+			// #88: pin self-key by id from envelope.
+			const selfKeyId = isSelf ? senderKeyId : receiverKeyId;
+			let selfKey = await this.getE2EESelfKeyDataByKeyId(selfKeyId);
+			if (!selfKey) {
+				selfKey = await this.getE2EESelfKeyData(
+					this.client.profile!.mid as string,
+				);
+			}
+			privK = Buffer.from(selfKey.privKey, "base64");
 			pubK = await this.getE2EELocalPublicKey(
-				to,
+				isSelf ? to : _from,
 				isSelf ? receiverKeyId : senderKeyId,
 			);
 		} else {
+			const selfKey = await this.getE2EESelfKeyData(
+				this.client.profile?.mid as string,
+			);
 			const groupK = await this.getE2EELocalPublicKey(
 				to,
 				receiverKeyId,


### PR DESCRIPTION
## Summary

`decryptE2EELocationMessage` could never successfully decrypt a received E2EE location message, for two independent reasons:

### 1. AAD content type: string `"LOCATION"` → NaN → 0 (≠ 15)

Incoming messages carry the enum *name* (`"LOCATION"`) because `rename_thrift` maps numeric enums back to strings. The encrypt side hardcodes the correct value in the AAD:

```ts
// encryptE2EELocationMessage
const aad = this.generateAAD(to, _from, senderKeyId, receiverKeyId, specVersion, 15);
```

but the decrypt path passed `messageObj.contentType` straight through as `contentType as number`. `getIntBytes("LOCATION")` → `setInt32(0, NaN)` → writes `0`, so the decryptor built an AAD with `f = 0` while the ciphertext was authenticated with `f = 15` — GCM auth verification always failed. The retry block then retried with identical inputs and rethrew.

`decryptE2EEDataMessage` already handles this correctly (`LINETypes.enums.ContentType[messageObj.contentType]`); the location path now does the same.

### 2. `isSelf` defaulted to `true` and was never derived

Unlike `decryptE2EETextMessage` / `decryptE2EEDataMessage`, the location path never checked `_from === profile.mid`, and its default parameter was `true`. The only caller (`decryptE2EEMessage`) passes no `isSelf`, so *every* location message was treated as self-sent: for a received 1:1 message it fetched my own public key via `getE2EELocalPublicKey(to=myMid, …)` and computed ECDH(myPriv, myPub) instead of ECDH(myPriv, senderPub) — always the wrong shared secret.

It also never pinned the self private key by envelope key id (#88), so it additionally broke on key rotation — exactly what #88 fixed for the text/data paths. The function now mirrors those two:

- `isSelf = false` default, derived from `from === profile.mid`
- self-key pinned by `senderKeyId`/`receiverKeyId` with latest-key fallback
- peer key looked up as `(to, receiverKeyId)` when self-sent, `(_from, senderKeyId)` when received

## Testing

- New `location_decrypt.test.ts` (same trap-the-primitive approach as `key_selection.test.ts`), 3 cases:
  - received: AAD contentType is numeric `15`, self-key pinned by `receiverKeyId`, peer pubKey looked up as `(_from, senderKeyId)`
  - self-sent: `isSelf` derived from mid, peer pubKey looked up as `(to, receiverKeyId)`
  - by-id miss falls back to latest key
- Full suite: `deno test --allow-all` — 217 passed, 0 failed.
