### PR TITLE
fix(e2ee): scope public-key cache by mid to prevent cross-contact key mixups

### DIFF
--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -109,11 +109,15 @@ export class E2EE {
 		const toType = this.client.getToType(mid);
 
 		if (toType === LINETypes.enums.MIDType.USER) {
+			// Cache keys must include the mid: LINE key ids are small
+			// per-account counters (each user's first key is typically 1 or 2),
+			// so a keyId-only cache key collides across contacts and returns
+			// one contact's public key for another — producing wrong ECDH
+			// shared secrets and undecryptable messages.
+			const cacheKey = `e2eePublicKeys:${mid}:${keyId}`;
 			let key: string | undefined = undefined;
 			if (keyId !== undefined) {
-				key = (await this.client.storage.get(
-					`e2eePublicKeys:${keyId}`,
-				)) as string;
+				key = (await this.client.storage.get(cacheKey)) as string;
 			}
 			let receiverKeyData: LINETypes.E2EENegotiationResult;
 			if (!key) {
@@ -126,10 +130,10 @@ export class E2EE {
 				}
 				const publicKey = receiverKeyData.publicKey;
 				const receiverKeyId = publicKey.keyId;
-				if (receiverKeyId == keyId) {
+				if (keyId === undefined || receiverKeyId == keyId) {
 					key = Buffer.from(publicKey.keyData).toString("base64");
 					await this.client.storage.set(
-						`e2eePublicKeys:${keyId}`,
+						`e2eePublicKeys:${mid}:${receiverKeyId}`,
 						key,
 					);
 				} else {

--- a/packages/linejs/base/e2ee/publickey_cache.test.ts
+++ b/packages/linejs/base/e2ee/publickey_cache.test.ts
@@ -1,0 +1,73 @@
+import { assert, assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { E2EE } from "./mod.ts";
+
+/** The per-user E2EE public key cache was keyed only by `keyId`
+ *  (`e2eePublicKeys:${keyId}`). LINE key ids are small per-account counters,
+ *  so two contacts both having key id 1 collided: the second contact's lookup
+ *  returned the first contact's cached public key without any RPC, producing
+ *  a wrong ECDH shared secret. */
+function makeE2EE() {
+	const store = new Map<string, string>();
+	const negotiatedFor: string[] = [];
+	const fakeBase = {
+		profile: { mid: "u-self" },
+		storage: {
+			get(k: string) {
+				return Promise.resolve(store.get(k) ?? null);
+			},
+			set(k: string, v: string) {
+				store.set(k, v);
+				return Promise.resolve();
+			},
+		},
+		talk: {
+			negotiateE2EEPublicKey({ mid }: { mid: string }) {
+				negotiatedFor.push(mid);
+				// Every account's first registered key gets keyId 1, but each
+				// account has distinct key material.
+				return Promise.resolve({
+					specVersion: 2,
+					publicKey: {
+						keyId: 1,
+						keyData: Buffer.from(`pub-of-${mid}`),
+					},
+				});
+			},
+			getE2EEPublicKeys() {
+				return Promise.resolve([]);
+			},
+		},
+		getToType() {
+			return 0;
+		},
+		log() {},
+	};
+	return { e2ee: new E2EE(fakeBase as never), store, negotiatedFor };
+}
+
+Deno.test("getE2EELocalPublicKey — same keyId on two contacts does not cross-contaminate", async () => {
+	const { e2ee, negotiatedFor } = makeE2EE();
+
+	const keyA = await e2ee.getE2EELocalPublicKey("u-a", 1);
+	assertEquals(keyA.toString(), "pub-of-u-a");
+	assert(negotiatedFor.includes("u-a"));
+
+	// Contact B has the same keyId=1 — must NOT be served A's cached key.
+	const keyB = await e2ee.getE2EELocalPublicKey("u-b", 1);
+	assertEquals(keyB.toString(), "pub-of-u-b");
+	assert(negotiatedFor.includes("u-b"));
+
+	// And repeated lookups still hit the (per-mid) cache.
+	const keyA2 = await e2ee.getE2EELocalPublicKey("u-a", 1);
+	assertEquals(keyA2.toString(), "pub-of-u-a");
+	assertEquals(negotiatedFor.filter((m) => m === "u-a").length, 1);
+});
+
+Deno.test("getE2EELocalPublicKey — omitted keyId accepts the negotiated key", async () => {
+	const { e2ee } = makeE2EE();
+	// Previously this threw `E2EE key id undefined not found` even though
+	// negotiation succeeded.
+	const key = await e2ee.getE2EELocalPublicKey("u-a");
+	assertEquals(key.toString(), "pub-of-u-a");
+});


### PR DESCRIPTION
## Summary

The per-user E2EE public key cache was keyed **only by `keyId`** (`e2eePublicKeys:${keyId}`), not by mid.

LINE E2EE key ids are small per-account counters — each account's first registered key typically gets id 1 or 2. With two or more E2EE-capable contacts, the cache slots collide:

- Decrypting a message from contact B returned contact A's cached public key (no RPC was even attempted for B), producing a wrong ECDH shared secret and a GCM auth failure.
- Each successful `negotiateE2EEPublicKey` overwrote the shared slot, so two contacts with the same keyId continuously evicted each other's keys.
- The group path is affected too, since the creator key is fetched through the same function.

This also masked itself on the send side: `encryptE2EEMessage` calls `negotiateE2EEPublicKey` directly and never touches this cache.

### Fix

Cache key becomes `e2eePublicKeys:${mid}:${keyId}` (read + write). Old keyId-only entries are simply never hit again and get re-negotiated once per contact — no migration needed.

Also fixes a latent always-throw path in the same block: when callers omitted `keyId`, negotiation succeeded but `receiverKeyId == undefined` was always false, throwing `` `E2EE key id undefined not found…` `` and wasting an RPC. An omitted `keyId` now means "accept whatever the server negotiated" (cached under its actual id).

## Testing

New `publickey_cache.test.ts`:

1. Two contacts both with keyId 1: each lookup negotiates and returns that contact's own key material; repeated lookups still hit the per-mid cache (no extra RPC).
2. Omitted `keyId`: previously threw `InternalError`; now returns the negotiated key.

Full suite: `deno test --allow-all` — 216 passed, 0 failed.
