### PR TITLE
fix(auth): persist rotated refresh token from tokenrefresh response

### DIFF
--- a/packages/linejs/base/service/auth/mod.test.ts
+++ b/packages/linejs/base/service/auth/mod.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "@std/assert";
+import { AuthService } from "./mod.ts";
+
+function makeStubClient(rotated: boolean) {
+	const store = new Map<string, string>([
+		["refreshToken", "rt-old"],
+	]);
+	return {
+		store,
+		client: {
+			authToken: "authtoken",
+			emit() {},
+			storage: {
+				get(k: string) {
+					return Promise.resolve(store.get(k) ?? null);
+				},
+				set(k: string, v: string) {
+					store.set(k, v);
+					return Promise.resolve();
+				},
+			},
+			request: {
+				request() {
+					return Promise.resolve({
+						accessToken: "at-new",
+						tokenIssueTimeEpochSec: 1000,
+						durationUntilRefreshInSec: 3600,
+						...(rotated ? { refreshToken: "rt-new" } : {}),
+					});
+				},
+			},
+		},
+	};
+}
+
+// RefreshAccessTokenResponse carries a `refreshToken` field because the
+// server may rotate it. Dropping it meant the next refresh reused the stale
+// token and failed.
+Deno.test("tryRefreshToken persists a rotated refreshToken", async () => {
+	const stub = makeStubClient(true);
+	const auth = new AuthService(stub.client as never);
+
+	await auth.tryRefreshToken();
+
+	assertEquals(stub.store.get("refreshToken"), "rt-new");
+	assertEquals(String(stub.store.get("expire")), "4600");
+});
+
+Deno.test("tryRefreshToken keeps the stored refreshToken when not rotated", async () => {
+	const stub = makeStubClient(false);
+	const auth = new AuthService(stub.client as never);
+
+	await auth.tryRefreshToken();
+
+	assertEquals(stub.store.get("refreshToken"), "rt-old");
+});

--- a/packages/linejs/base/service/auth/mod.ts
+++ b/packages/linejs/base/service/auth/mod.ts
@@ -24,6 +24,12 @@ export class AuthService implements BaseService {
 			const RATR = await this.refresh({ request: { refreshToken } });
 			this.client.authToken = RATR.accessToken;
 			this.client.emit("update:authtoken", RATR.accessToken);
+			// The server may rotate the refresh token; persisting it is
+			// required, otherwise the next refresh reuses a stale token and
+			// fails.
+			if (RATR.refreshToken) {
+				await this.client.storage.set("refreshToken", RATR.refreshToken);
+			}
 			await this.client.storage.set(
 				"expire",
 				(RATR.tokenIssueTimeEpochSec as number) +


### PR DESCRIPTION
## Summary

`AuthService.tryRefreshToken()` discarded the rotated refresh token returned by the server.

`RefreshAccessTokenResponse` explicitly carries a `refreshToken` field (packages/types/line_types.ts:13446), and every login path persists the initial one (`client/login.ts:110-111`, `base/login/mod.ts:163-164, 306, 618`) — but the refresh path only updated `accessToken` and `expire`:

```ts
const RATR = await this.refresh({ request: { refreshToken } });
this.client.authToken = RATR.accessToken;
await this.client.storage.set("expire", ...);
// RATR.refreshToken silently dropped
```

If the server rotates the token (the reason the field exists), the next `tryRefreshToken()` reuses a stale/invalidated token and dies with a refresh error — permanently breaking long-lived sessions that rely on periodic token refresh.

### Fix

Persist `RATR.refreshToken` when present, before writing `expire`.

## Testing

New `mod.test.ts` following the existing stub-client pattern (`relation/mod.test.ts`):

1. Response containing a rotated token → storage now holds `"rt-new"`.
2. Response without rotation → previously stored token is left untouched.

Full suite: `deno test --allow-all` passes.
