### PR TITLE
fix(liff): consent POST used hardcoded channelId; sendLiff ignored tryConsent

### DIFF
--- a/packages/linejs/base/service/liff/mod.ts
+++ b/packages/linejs/base/service/liff/mod.ts
@@ -117,14 +117,13 @@ export class LiffService implements BaseService {
 				const error = e as InternalError;
 
 				this.client.log("liff-error", { ...error.data });
+				const liffException = error.data
+					.liffException as LINETypes.LiffException | undefined;
 				if (
-					(error.data.liffException as LINETypes.LiffException)
-							.code ===
-						"CONSENT_REQUIRED" &&
+					liffException?.code === "CONSENT_REQUIRED" &&
 					tryConsent
 				) {
-					const data = error
-						.data.liffException as LINETypes.LiffException;
+					const data = liffException;
 					const payload = data.payload;
 					const { channelId, consentUrl } = payload.consentRequired;
 					const toType = chatMid && this.client.getToType(chatMid);
@@ -168,7 +167,7 @@ export class LiffService implements BaseService {
 		const {
 			to,
 			messages,
-			tryConsent: _tryConsent,
+			tryConsent,
 			forceIssue,
 		} = {
 			tryConsent: true,
@@ -179,6 +178,7 @@ export class LiffService implements BaseService {
 			token = await this.getLiffToken({
 				chatMid: to,
 				liffId: this.liffId,
+				tryConsent,
 			});
 		} else {
 			token = this.liffTokenCache[to];
@@ -277,7 +277,7 @@ export class LiffService implements BaseService {
 								.join("&")
 						}&${
 							approvedPermission.map((e) => "approvedPermission=" + e).join("&")
-						}&__WLS=&channelId=2006747340&__csrf=${csrfToken}&allow=true`,
+						}&__WLS=&channelId=${channelId}&__csrf=${csrfToken}&allow=true`,
 						headers,
 					},
 				);


### PR DESCRIPTION
## Summary

Three related LIFF consent-flow fixes in `base/service/liff/mod.ts`:

### 1. Consent was always POSTed for the library's own channel id (high impact)

`tryConsentAuthorize` receives the third-party `channelId` from the `CONSENT_REQUIRED` exception, validates it, extracts the CSRF token from *that* channel's consent page — then posted a **hardcoded** id copied from the bundled LIFF app constant:

```ts
body: `...&__WLS=&channelId=2006747340&__csrf=${csrfToken}&allow=true`
```

Consent for any other channel was submitted as consent for channel `2006747340` (with a mismatched CSRF/session), so the flow failed for third-party LIFF apps or granted the wrong channel. The body now uses the actual `channelId` parameter.

### 2. `sendLiff()` accepted but ignored `tryConsent`

The option was destructured into an unused `_tryConsent` binding while `getLiffToken` was called without it, so `sendLiff({ tryConsent: false })` still triggered the full interactive consent flow. The option is now forwarded.

### 3. Missing `liffException` crashed with an unrelated TypeError

In `getLiffToken`'s catch, `(error.data.liffException).code` throws `TypeError: Cannot read properties of undefined` whenever an `InternalError` carries `data` without a `liffException` member (e.g. a plain TalkException from `/LIFF1`), bypassing both the CONSENT_REQUIRED handling and the wrapping `InternalError`. Now guarded with optional chaining so the caller gets the proper `LiffServiceError`.

## Testing

- `deno check packages/linejs/base/service/liff/mod.ts` passes.
- Fix 1 verified by inspection: the parameter is already validated truthy at the call site (`if (channelId && csrfToken)`), so interpolation cannot regress to the old behavior.
- Full suite: `deno test --allow-all` passes.
