### PR TITLE
fix(client): read() chat target, dead unsend() guard, i64 fetch cursor

### DIFF
--- a/packages/linejs/client/features/chat/fetcher.test.ts
+++ b/packages/linejs/client/features/chat/fetcher.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import { createMessageFetcher } from "./fetcher.ts";
+import type { Client } from "../../client.ts";
+
+// Message ids are 64-bit values; parseInt silently rounds them beyond
+// 2^53, corrupting the pagination cursor. Also, an empty page (end of
+// history) previously crashed on `messages.at(-1)!`.
+Deno.test("fetch uses a lossless bigint cursor and tolerates empty pages", async () => {
+	const requests: unknown[] = [];
+	const client = {
+		base: {
+			talk: {
+				async getMessageBoxes() {
+					return {
+						messageBoxes: [
+							{
+								id: "c-chat",
+								lastDeliveredMessageId: {
+									deliveredTime: 100,
+									messageId: 9007199254740993n,
+								},
+							},
+						],
+					};
+				},
+				async getPreviousMessagesV2WithRequest({
+					request,
+				}: {
+					request: { endMessageId: { messageId: bigint | number } };
+				}) {
+					requests.push(request.endMessageId.messageId);
+					if (requests.length === 1) {
+						return [
+							{
+								id: "9007199254740993", // 2^53 + 1
+								deliveredTime: 100,
+								contentType: "NONE",
+								contentMetadata: {},
+								text: "hi",
+							},
+						];
+					}
+					return [];
+				},
+			},
+		},
+	} as never as Client;
+
+	const chat = { mid: "c-chat" } as never;
+	const fetcher = await createMessageFetcher(client, chat);
+
+	const page1 = await fetcher.fetch(10);
+	assertEquals(page1.length, 1);
+
+	const page2 = await fetcher.fetch(10);
+	assertEquals(page2.length, 0);
+
+	assertEquals(requests[0], 9007199254740993n);
+	assertEquals(requests[1], 9007199254740993n);
+});

--- a/packages/linejs/client/features/chat/fetcher.ts
+++ b/packages/linejs/client/features/chat/fetcher.ts
@@ -25,10 +25,15 @@ export const createMessageFetcher = async (client: Client, chat: Chat) => {
 					messagesCount: limit,
 				},
 			});
+			if (!messages.length) {
+				return [];
+			}
 			const lastMessage = messages.at(-1)!;
+			// Message ids are 64-bit values far beyond Number.MAX_SAFE_INTEGER;
+			// parseInt silently rounds them and corrupts the pagination cursor.
 			lastMessageId = {
 				deliveredTime: lastMessage.deliveredTime,
-				messageId: parseInt(lastMessage.id),
+				messageId: BigInt(lastMessage.id),
 			};
 
 			return await Promise.all(

--- a/packages/linejs/client/features/message/square.test.ts
+++ b/packages/linejs/client/features/message/square.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { SquareMessage } from "./square.ts";
+import type { Client } from "../../client.ts";
+
+// `isMyMessage` is an async *method*, but `unsend()` tested it as a property
+// — a function object is always truthy, so the ownership guard never fired.
+Deno.test("unsend rejects messages that are not mine", async () => {
+	const client = {
+		base: {
+			profile: { mid: "u-self" },
+			square: {
+				async getSquareChat() {
+					return { squareChatMember: { squareMemberMid: "u-owner" } };
+				},
+				unsendMessage() {
+					throw new Error("must not be called");
+				},
+			},
+		},
+	} as never as Client;
+	const msg = new SquareMessage({
+		client,
+		raw: {
+			message: {
+				id: "sq-1",
+				to: "sq-chat",
+				from: "u-other",
+				toType: "SQUARE",
+				contentType: "NONE",
+				contentMetadata: {},
+				text: "hi",
+				createdTime: 0,
+			},
+			fromType: "USER",
+		} as never,
+	});
+
+	await assertRejects(
+		() => msg.unsend(),
+		TypeError,
+		"Cannot unsend the message which is not yours.",
+	);
+});

--- a/packages/linejs/client/features/message/square.ts
+++ b/packages/linejs/client/features/message/square.ts
@@ -142,7 +142,7 @@ export class SquareMessage {
 	 * Unsends the message.
 	 */
 	async unsend(): Promise<void> {
-		if (!this.isMyMessage) {
+		if (!(await this.isMyMessage())) {
 			throw new TypeError(
 				"Cannot unsend the message which is not yours.",
 			);
@@ -451,7 +451,7 @@ export class SquareThreadMessage extends SquareMessage {
 	#authorIsMe?: boolean;
 
 	constructor(init: SquareThreadMessageInit) {
-		super(init)
+		super(init);
 		this.#client = init.client;
 		this.raw = init.raw;
 	}
@@ -588,7 +588,7 @@ export class SquareThreadMessage extends SquareMessage {
 	 * Unsends the message.
 	 */
 	override async unsend() {
-		if (!this.isMyMessage) {
+		if (!(await this.isMyMessage())) {
 			throw new TypeError(
 				"Cannot unsend the message which is not yours.",
 			);
@@ -611,7 +611,10 @@ export class SquareThreadMessage extends SquareMessage {
 		});
 	}
 
-	static override fromSource(source: SquareEvent, client: Client): SquareThreadMessage {
+	static override fromSource(
+		source: SquareEvent,
+		client: Client,
+	): SquareThreadMessage {
 		return new SquareThreadMessage({
 			client,
 			raw: source.payload.notificationThreadMessage.squareMessage,

--- a/packages/linejs/client/features/message/talk.test.ts
+++ b/packages/linejs/client/features/message/talk.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { TalkMessage } from "./talk.ts";
+import type { Client } from "../../client.ts";
+
+function makeClient() {
+	const chatCheckedCalls: unknown[] = [];
+	const client = {
+		base: {
+			profile: { mid: "u-self" },
+			getReqseq: () => Promise.resolve(1),
+			talk: {
+				sendChatChecked(opts: unknown) {
+					chatCheckedCalls.push(opts);
+					return Promise.resolve({});
+				},
+			},
+		},
+	} as never as Client;
+	return { client, chatCheckedCalls };
+}
+
+function makeRaw(opts: {
+	to: string;
+	from: string;
+	toType: string;
+	id?: string;
+}) {
+	return {
+		id: opts.id ?? "msg-1",
+		to: opts.to,
+		from: opts.from,
+		toType: opts.toType,
+		contentType: "NONE",
+		contentMetadata: {},
+		text: "hi",
+	} as never;
+}
+
+// `chatMid` must be the chat id. In group chats `from` is the sender's USER
+// mid, so marking a received group message read previously targeted a
+// non-existent 1:1 chat.
+Deno.test("read marks the group chat itself as read for received group messages", async () => {
+	const { client, chatCheckedCalls } = makeClient();
+	const msg = new TalkMessage({
+		client,
+		raw: makeRaw({ to: "g-group", from: "u-them", toType: "GROUP" }),
+	});
+
+	await msg.read();
+
+	assertEquals(chatCheckedCalls[0], {
+		chatMid: "g-group",
+		lastMessageId: "msg-1",
+		seq: 1,
+	});
+});
+
+Deno.test("read keeps 1:1 behavior (counterpart mid) for received DMs", async () => {
+	const { client, chatCheckedCalls } = makeClient();
+	const msg = new TalkMessage({
+		client,
+		raw: makeRaw({ to: "u-self", from: "u-them", toType: "USER" }),
+	});
+
+	await msg.read();
+
+	assertEquals(chatCheckedCalls[0], {
+		chatMid: "u-them",
+		lastMessageId: "msg-1",
+		seq: 1,
+	});
+});

--- a/packages/linejs/client/features/message/talk.ts
+++ b/packages/linejs/client/features/message/talk.ts
@@ -114,8 +114,15 @@ export class TalkMessage {
 	 * Read the message.
 	 */
 	async read(): Promise<void> {
+		// `chatMid` must be the chat id. In group/room chats `from` is the
+		// sender's USER mid, not the chat, so mark the chat itself read.
+		const chatMid = this.to.type === "GROUP" || this.to.type === "ROOM"
+			? this.to.id
+			: this.isMyMessage
+			? this.to.id
+			: this.from.id;
 		await this.#client.base.talk.sendChatChecked({
-			chatMid: this.isMyMessage ? this.to.id : this.from.id,
+			chatMid,
 			lastMessageId: this.raw.id,
 			seq: await this.#client.base.getReqseq(),
 		});


### PR DESCRIPTION
## Summary

Three client-facing bugs, each verified with a failing call before the fix:

### 1. `TalkMessage.read()` marked the wrong chat as read for received group messages

```ts
chatMid: this.isMyMessage ? this.to.id : this.from.id
```

For a group/room message received from someone else, `from.id` is the **sender's USER mid**, but `sendChatChecked`'s `chatMid` must be the chat id — so `.read()` targeted a (usually non-existent) 1:1 chat instead of the group. The neighboring `reply()`/`send()` already branch on `toType`, which makes this look like an oversight.

Now: GROUP/ROOM → always `to.id`; USER chats keep the previous behavior (counterpart mid).

### 2. `SquareMessage.unsend()` / `SquareThreadMessage.unsend()` ownership guard was dead code

`isMyMessage` is an async *method* on square messages, but both `unsend()` implementations tested it as a property:

```ts
if (!this.isMyMessage) { throw new TypeError(...) }
```

`this.isMyMessage` is a function object — always truthy — so the guard never fired and `unsend()` proceeded for anyone's message. Now awaited properly. (`TalkMessage.unsend()` is unaffected; its `isMyMessage` is a getter.)

### 3. Message-fetcher pagination cursor lost i64 precision + crashed on empty pages

`createMessageFetcher().fetch()` did:

- `parseInt(lastMessage.id)` — LINE message ids are ~19-digit values beyond `Number.MAX_SAFE_INTEGER`, so the next page's cursor was silently rounded, skipping/duplicating messages. Now `BigInt(lastMessage.id)` (the struct writer already supports bigint I64).
- `messages.at(-1)!` — threw `TypeError` when a fetch returned an empty array (end of history). Empty pages now return `[]` with the cursor left unchanged.

## Testing

New tests: `talk.test.ts` (group read targets chat mid; 1:1 unchanged), `square.test.ts` (unsend of another member's message throws TypeError without calling `unsendMessage`), `fetcher.test.ts` (2^53+1 cursor round-trips losslessly; empty page returns `[]` without throwing).

Full suite: `deno test --allow-all` — 218 passed, 0 failed.
