### PR TITLE
fix(polling): no-operations sync response caused hot spin that ignored abort

### DIFF
--- a/packages/linejs/base/polling/mod.test.ts
+++ b/packages/linejs/base/polling/mod.test.ts
@@ -1,0 +1,40 @@
+import { assert } from "@std/assert";
+import { Polling } from "./mod.ts";
+
+// A response without `operationResponse.operations` used to hit an early
+// `continue`, skipping the sleep AND the abort check — a hot spin that
+// hammered talk.sync and ignored the AbortSignal.
+Deno.test("_listenTalkEvents sleeps between polls and honors abort", async () => {
+	let syncCalls = 0;
+	const client = {
+		authToken: "token",
+		talk: {
+			sync() {
+				syncCalls++;
+				return Promise.resolve({});
+			},
+		},
+		log() {},
+	};
+	const polling = new Polling(client as never);
+
+	const controller = new AbortController();
+	setTimeout(() => controller.abort(), 150);
+
+	const start = Date.now();
+	for await (
+		const _ of polling._listenTalkEvents({
+			signal: controller.signal,
+			pollingInterval: 50,
+		})
+	) {
+		// no events expected
+	}
+	const elapsed = Date.now() - start;
+
+	assert(
+		syncCalls <= 8,
+		`expected a bounded number of polls, got ${syncCalls}`,
+	);
+	assert(elapsed >= 100, `loop ended too early (${elapsed}ms)`);
+});

--- a/packages/linejs/base/polling/mod.ts
+++ b/packages/linejs/base/polling/mod.ts
@@ -124,15 +124,18 @@ export class Polling {
 						response.operationResponse.individualEvents
 							.lastRevision;
 				}
+				// Only iterate operations when present; falling through to the
+				// shared sleep/abort tail is required — an early `continue` here
+				// used to busy-loop without delay and made the AbortSignal
+				// unobservable.
 				if (
-					!(response.operationResponse &&
-						response.operationResponse.operations)
+					response.operationResponse &&
+					response.operationResponse.operations
 				) {
-					continue;
-				}
-				for (const event of response.operationResponse.operations) {
-					this.sync.talk.revision = event.revision;
-					yield event;
+					for (const event of response.operationResponse.operations) {
+						this.sync.talk.revision = event.revision;
+						yield event;
+					}
 				}
 			} catch (error) {
 				if (onError) {


### PR DESCRIPTION
## Summary

`Polling._listenTalkEvents` (the deprecated but still exported polling generator) busy-looped whenever a sync response arrived without `operationResponse.operations`, which happens routinely (e.g. full-sync-only responses):

```ts
if (!(response.operationResponse && response.operationResponse.operations)) {
    continue; // skips sleep AND the AbortSignal check
}
```

The `continue` jumped back to `while (true)` without executing `await sleep(pollingInterval)` or `if (signal?.aborted) break`. Consequences:

- `talk.sync` was hammered as fast as the event loop allowed (rate-limit / ban risk),
- an `AbortSignal` could never stop the loop, because abort is only checked after the sleep.

### Fix

Replace the early `continue` with a positive condition around the operations loop so every iteration falls through to the shared sleep/abort tail.

## Testing

New `mod.test.ts`: stubs `talk.sync` to resolve `{}` (no operations), polls with a 50 ms interval, aborts after 150 ms. Asserts the poll count stays bounded and the loop actually terminates. On the old code this test never completes — the abort is ignored and syncCalls explodes.

Full suite: `deno test --allow-all` passes.
