### PR TITLE
fix(e2ee): verify HMAC in decryptByKeyMaterial (tampered media silently accepted)

### DIFF
--- a/packages/linejs/base/e2ee/keymaterial_hmac.test.ts
+++ b/packages/linejs/base/e2ee/keymaterial_hmac.test.ts
@@ -1,0 +1,78 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { E2EE } from "./mod.ts";
+import { InternalError } from "../core/utils/error.ts";
+
+// `encryptByKeyMaterial` appends an HMAC-SHA256 of the ciphertext, but
+// `decryptByKeyMaterial` silently discarded those 32 bytes without ever
+// comparing them — tampered/corrupted media decrypted to garbage without
+// error.
+function makeE2EE() {
+	return new E2EE({
+		profile: { mid: "u-self" },
+		storage: {
+			get() {
+				return Promise.resolve(null);
+			},
+			set() {
+				return Promise.resolve();
+			},
+		},
+		getToType() {
+			return 0;
+		},
+		log() {},
+	} as never);
+}
+
+Deno.test("decryptByKeyMaterial round-trips and verifies the HMAC", async () => {
+	const e2ee = makeE2EE();
+	const raw = Buffer.from("secret media payload");
+
+	const { keyMaterial, encryptedData } = await e2ee.encryptByKeyMaterial(raw);
+	assertEquals(encryptedData.length, raw.length + 32);
+
+	const decrypted = await e2ee.decryptByKeyMaterial(
+		encryptedData,
+		keyMaterial,
+	);
+	assertEquals(decrypted.toString(), "secret media payload");
+});
+
+Deno.test("decryptByKeyMaterial rejects a tampered ciphertext", async () => {
+	const e2ee = makeE2EE();
+	const { keyMaterial, encryptedData } = await e2ee.encryptByKeyMaterial(
+		Buffer.from("secret media payload"),
+	);
+
+	const tampered = Buffer.from(encryptedData);
+	tampered[0] ^= 0x01;
+	await assertRejects(
+		() => e2ee.decryptByKeyMaterial(tampered, keyMaterial),
+		InternalError as never,
+		"HMAC verification failed",
+	);
+});
+
+Deno.test("decryptByKeyMaterial rejects a wrong keyMaterial", async () => {
+	const e2ee = makeE2EE();
+	const { encryptedData } = await e2ee.encryptByKeyMaterial(
+		Buffer.from("secret media payload"),
+	);
+
+	await assertRejects(
+		() => e2ee.decryptByKeyMaterial(encryptedData, Buffer.alloc(32, 7)),
+		InternalError as never,
+		"HMAC verification failed",
+	);
+});
+
+Deno.test("decryptByKeyMaterial rejects truncated input", async () => {
+	const e2ee = makeE2EE();
+	await assertRejects(
+		() => e2ee.decryptByKeyMaterial(Buffer.alloc(10), Buffer.alloc(32)),
+		InternalError as never,
+		"too short",
+	);
+	assert(true);
+});

--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -1346,11 +1346,24 @@ export class E2EE {
 			keyMaterial = Buffer.from(keyMaterial, "base64");
 		}
 		const keys = await this.deriveKeyMaterial(keyMaterial);
-		return (await this.___decryptAESCTR(keys.encKey, keys.nonce, rawData))
-			.slice(
-				0,
-				-32,
+		if (rawData.length < 32) {
+			throw new InternalError(
+				"E2EEMediaError",
+				`encrypted data too short (${rawData.length} bytes) to contain HMAC`,
 			);
+		}
+		const encData = rawData.subarray(0, -32);
+		const sign = rawData.subarray(-32);
+		const expected = this.signData(encData, keys.macKey);
+		if (
+			!crypto.timingSafeEqual(sign, expected)
+		) {
+			throw new InternalError(
+				"E2EEMediaError",
+				"HMAC verification failed: ciphertext was tampered with or keyMaterial is wrong",
+			);
+		}
+		return await this.___decryptAESCTR(keys.encKey, keys.nonce, encData);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`decryptByKeyMaterial` (the "E2EE Next" media decryption path) never verified the HMAC that `encryptByKeyMaterial` carefully computes and appends:

```ts
// encrypt side: HMAC-SHA256 of the ciphertext, appended
const sign = this.signData(encData, keys.macKey);
return { keyMaterial, encryptedData: Buffer.concat([encData, sign]) };

// decrypt side: sign silently discarded, never checked
return (await this.___decryptAESCTR(keys.encKey, keys.nonce, rawData)).slice(0, -32);
```

Any tampered or corrupted blob decrypted to garbage — or truncated garbage — without error, which is a real integrity failure for an E2EE media pipeline and makes the entire `macKey`/`signData` machinery dead weight.

### Fix

Split off the trailing 32-byte tag, recompute `signData(encData, macKey)` over the ciphertext only, and compare with `crypto.timingSafeEqual`. Throw an `InternalError("E2EEMediaError", …)` on mismatch or on inputs shorter than the 32-byte tag.

Decryption result is unchanged for authentic data: AES-CTR is a stream cipher, so decrypting `ciphertext||tag` and slicing was equivalent to decrypting `ciphertext`.

## Testing

New `keymaterial_hmac.test.ts`, 4 cases:

1. Round-trip returns the original plaintext.
2. A single flipped bit in the ciphertext → rejected with "HMAC verification failed".
3. Wrong `keyMaterial` → rejected (previously decrypted silently to garbage).
4. Input shorter than 32 bytes → rejected as too short instead of producing a negative-length slice.

Full suite: `deno test --allow-all` — 218 passed, 0 failed.
