### PR TITLE
feat(client): add message:edit event for edited messages

### DIFF
--- a/docs/docs/message-event.md
+++ b/docs/docs/message-event.md
@@ -84,6 +84,29 @@ That's all!\
 There are also `send`, `reaction`, etc.\
 Let me explain all the methods in other chapters.
 
+## Edited messages
+
+When a message is edited, LINE does not send it again through `message`. Listen
+to `message:edit` instead.
+
+```ts
+client.on("message:edit", (message) => {
+    console.log(message.raw.id, "was edited to:", message.text);
+});
+```
+
+The edited message keeps the **id of the original message**, so you can replace
+your cached copy by id. `message.isEdited` is `true` and
+`message.updatedTime` holds the time of the edit.
+
+The event fires both when someone else edits a message and when you edit one
+from another device.
+
+:::warning
+Only receiving edits is supported. Editing a message *from* linejs is not
+implemented.
+:::
+
 ## Square
 
 So what should we do with Square (OpenChat)? Basically the same thing.

--- a/packages/linejs/client/client.ts
+++ b/packages/linejs/client/client.ts
@@ -70,6 +70,12 @@ export interface ListenOptions {
 }
 export type ClientEvents = {
 	message: (message: TalkMessage) => void;
+	/**
+	 * Fired when a talk message is edited.
+	 * The message keeps the id of the original message, so consumers can
+	 * replace their cached copy by id.
+	 */
+	"message:edit": (message: TalkMessage) => void;
 	event: (event: LINETypes.Operation) => void;
 	"square:message": (message: SquareMessage) => void;
 	"square:event": (event: LINETypes.SquareEvent) => void;
@@ -138,6 +144,23 @@ export class Client extends TypedEventEmitter<ClientEvents> {
 					) {
 						this.emit(
 							"message",
+							new TalkMessage({
+								raw: await this.base.e2ee.decryptE2EEMessage(
+									event.message,
+								),
+								client: this,
+							}),
+						);
+					} else if (
+						// 159: someone else edited a message in a chat we are in.
+						event.type === "NOTIFIED_EDIT_MESSAGE" ||
+						// 158: we edited a message ourselves, synced from another
+						// device. Both are surfaced for the same reason
+						// SEND_MESSAGE and RECEIVE_MESSAGE both emit "message".
+						event.type === "EDIT_MESSAGE"
+					) {
+						this.emit(
+							"message:edit",
 							new TalkMessage({
 								raw: await this.base.e2ee.decryptE2EEMessage(
 									event.message,

--- a/packages/linejs/client/features/message/talk.test.ts
+++ b/packages/linejs/client/features/message/talk.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import type { Message } from "@evex/linejs-types";
+import type { Client } from "../../client.ts";
+import { TalkMessage } from "./talk.ts";
+
+function message(raw: Partial<Message>): TalkMessage {
+	return new TalkMessage({
+		client: {} as Client,
+		raw: raw as Message,
+	});
+}
+
+Deno.test("TalkMessage.isEdited — never edited", () => {
+	assertEquals(message({ text: "hi" }).isEdited, false);
+	assertEquals(message({ text: "hi", updatedTime: 0 }).isEdited, false);
+	assertEquals(message({ text: "hi", updatedTime: 0n }).isEdited, false);
+	assertEquals(
+		message({ text: "hi", contentMetadata: { e2eeVersion: "2" } }).isEdited,
+		false,
+	);
+});
+
+// EDIT_MESSAGE / NOTIFIED_EDIT_MESSAGE operations mark the edit in
+// contentMetadata, not in the `updatedTime` field. Shape taken from a live
+// op 158 payload.
+Deno.test("TalkMessage.isEdited — edit operation metadata", () => {
+	const m = message({
+		id: "1234567890123456789",
+		contentMetadata: {
+			e2eeVersion: "2",
+			EDITED: "true",
+			UPDATED_TIME: "1787927539000",
+		},
+	});
+	assertEquals(m.isEdited, true);
+	assertEquals(m.updatedTime, 1787927539000);
+});
+
+Deno.test("TalkMessage.isEdited — updatedTime field", () => {
+	assertEquals(
+		message({ text: "hi", updatedTime: 1700000000000 }).isEdited,
+		true,
+	);
+	assertEquals(
+		message({ text: "hi", updatedTime: 1700000000000n }).isEdited,
+		true,
+	);
+});
+
+Deno.test("TalkMessage.updatedTime", () => {
+	assertEquals(message({ text: "hi" }).updatedTime, null);
+	assertEquals(message({ text: "hi", updatedTime: 0 }).updatedTime, null);
+	assertEquals(
+		message({ text: "hi", updatedTime: 1700000000000 }).updatedTime,
+		1700000000000,
+	);
+	// metadata wins over the field
+	assertEquals(
+		message({
+			updatedTime: 1700000000000,
+			contentMetadata: { UPDATED_TIME: "1787927539000" },
+		}).updatedTime,
+		1787927539000,
+	);
+});

--- a/packages/linejs/client/features/message/talk.ts
+++ b/packages/linejs/client/features/message/talk.ts
@@ -417,6 +417,28 @@ export class TalkMessage {
 	get text(): string {
 		return this.raw.text;
 	}
+	/**
+	 * Whether the message has been edited.
+	 */
+	get isEdited(): boolean {
+		// EDIT_MESSAGE / NOTIFIED_EDIT_MESSAGE operations carry the marker in
+		// contentMetadata; `updatedTime` is only set on messages fetched from
+		// the message box.
+		return this.raw.contentMetadata?.EDITED === "true" ||
+			Boolean(this.raw.updatedTime);
+	}
+	/**
+	 * Time the message was last edited, or `null` when it has never been
+	 * edited.
+	 */
+	get updatedTime(): number | bigint | null {
+		const fromMetadata = this.raw.contentMetadata?.UPDATED_TIME;
+		if (fromMetadata) {
+			const parsed = Number(fromMetadata);
+			if (!Number.isNaN(parsed)) return parsed;
+		}
+		return this.raw.updatedTime || null;
+	}
 	/*
 	static fromSource(
 		source: SourceEvent & { type: "talk" },


### PR DESCRIPTION
## Description

Adds a `message:edit` client event so edited talk messages come through the
high-level API.

LINE sends edits as two operations, both of which already exist in
`@evex/linejs-types`: `EDIT_MESSAGE` (158) for an edit by the logged-in user
synced from another device, and `NOTIFIED_EDIT_MESSAGE` (159) for an edit by
someone else. Both already reached `client.on("event")` as raw operations, but
`client.on("message")` only handles `SEND_MESSAGE` / `RECEIVE_MESSAGE`, so
consumers had to parse the operation themselves and call `decryptE2EEMessage`
by hand for Letter Sealing chats.

### Changes

- `ClientEvents` gains `"message:edit": (message: TalkMessage) => void`
- `listen()` emits it for 158 and 159, reusing the same `decryptE2EEMessage`
  path as `message`
- `TalkMessage` gains `isEdited` and `updatedTime` getters
- docs: new "Edited messages" section in `docs/docs/message-event.md`

Additive only, no behavior change to existing events.

`message:edit` fires for both 158 and 159, matching how `message` fires for
both `SEND_MESSAGE` and `RECEIVE_MESSAGE`. Not just for symmetry — editing a
message from the LINE app on my own account came through as 158, so handling
only 159 would miss the multi-device case.

Field 28 is absent from the payload for these operations. Both 158 and 159
carry the marker in `contentMetadata` instead:

    contentMetadata: { e2eeVersion: "2", EDITED: "true", UPDATED_TIME: "1787929553736" }

So `isEdited` / `updatedTime` read `contentMetadata` first and fall back to
`updatedTime`, which is what messages fetched from the message box carry. The
operation also carries the full edited `Message` in `operation.message`, and
the edited message keeps the id of the original, so consumers can replace a
cached copy by id.

## Testing

Unit tests in `packages/linejs/client/features/message/talk.test.ts` cover the
getters, using a payload shape captured from a real operation.

- `deno test -A` → 218 passed
- `deno publish --dry-run` → passes

Live-tested against my own accounts (ANDROIDSECONDARY session, edits made from
the LINE iOS app), covering 1:1, group, and Keep-memo chats:

- `EDIT_MESSAGE` (158): 3 operations, one in each of the three chat types
- `NOTIFIED_EDIT_MESSAGE` (159): 1 operation
- `message:edit` fires for both, the message `id` matches the original, and
  `isEdited` flips false → true across send/edit for the same id with
  `updatedTime` populated

I couldn't verify the decrypted text of an edit. My test session couldn't
decrypt E2EE messages at all (an unrelated pre-existing key issue on a fresh
secondary device), so `text` was empty for every message, edited or not. The
decrypt call does run on the edit path, and the operation carries the edited
body in `chunks`.

Separately: `decryptE2EEMessage` in `listen()` is unguarded, so a single
decryption failure throws out of the `for await` loop and stops the talk
listener entirely. I hit this during testing. It's pre-existing behavior on the
`message` branch and this PR follows the existing pattern rather than changing
it. Happy to open a separate issue if that's useful.

## Checklist

- [x] Run tests
- [x] Add jsdoc
- [x] Test in your environment
