### PR TITLE
fix: E2EE key registration and client message handling

### DIFF
--- a/packages/linejs/base/e2ee/mod.ts
+++ b/packages/linejs/base/e2ee/mod.ts
@@ -1159,7 +1159,7 @@ export class E2EE {
 				publicKey: {
 					version: 1,
 					keyId: 0,
-					keyData: pubKey.toString("base64"),
+					keyData: pubKey,
 					createdTime: 0,
 				},
 			});

--- a/packages/linejs/base/e2ee/register_keypair.test.ts
+++ b/packages/linejs/base/e2ee/register_keypair.test.ts
@@ -1,0 +1,34 @@
+import { assert, assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { E2EE } from "./mod.ts";
+
+Deno.test("registerE2EEKeyPair sends the raw 32-byte public key", async () => {
+	let registeredPublicKey: unknown;
+	const stored = new Map<string, string>();
+	const fakeBase = {
+		profile: { mid: "u-self" },
+		storage: {
+			set(key: string, value: string) {
+				stored.set(key, value);
+				return Promise.resolve();
+			},
+		},
+		talk: {
+			registerE2EEPublicKey({ publicKey }: { publicKey: unknown }) {
+				registeredPublicKey = publicKey;
+				return Promise.resolve({ keyId: 7 });
+			},
+		},
+		log() {},
+	};
+
+	const result = await new E2EE(fakeBase as never).registerE2EEKeyPair();
+	const keyData = (registeredPublicKey as { keyData: unknown }).keyData;
+
+	assert(Buffer.isBuffer(keyData));
+	assertEquals(keyData.length, 32);
+	assertEquals(result?.keyId, 7);
+	assertEquals(result?.pubKey.equals(keyData), true);
+	assert(stored.has("e2eeKeys:7"));
+	assert(stored.has("e2eeKeys:u-self"));
+});

--- a/packages/linejs/base/thrift/readwrite/struct.ts
+++ b/packages/linejs/base/thrift/readwrite/struct.ts
@@ -1,4 +1,5 @@
 import * as LINETypes from "@evex/linejs-types";
+import type { Buffer } from "node:buffer";
 import { type NestedArray } from "../mod.ts";
 function map(
 	call: ((v: any) => NestedArray) | ((v: any) => number),
@@ -5388,7 +5389,7 @@ export function Pb1_C13097n4(
 	return typeof param === "undefined" ? [] : [
 		[8, 1, param.version],
 		[8, 2, param.keyId],
-		[11, 4, param.keyData],
+		[11, 4, param.keyData as string | Buffer | undefined],
 		[10, 5, param.createdTime],
 	];
 }

--- a/packages/linejs/client/features/chat/fetcher.test.ts
+++ b/packages/linejs/client/features/chat/fetcher.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import { createMessageFetcher } from "./fetcher.ts";
+import type { Client } from "../../client.ts";
+
+// Message ids are 64-bit values; parseInt silently rounds them beyond
+// 2^53, corrupting the pagination cursor. Also, an empty page (end of
+// history) previously crashed on `messages.at(-1)!`.
+Deno.test("fetch uses a lossless bigint cursor and tolerates empty pages", async () => {
+	const requests: unknown[] = [];
+	const client = {
+		base: {
+			talk: {
+				async getMessageBoxes() {
+					return {
+						messageBoxes: [
+							{
+								id: "c-chat",
+								lastDeliveredMessageId: {
+									deliveredTime: 100,
+									messageId: 9007199254740993n,
+								},
+							},
+						],
+					};
+				},
+				async getPreviousMessagesV2WithRequest({
+					request,
+				}: {
+					request: { endMessageId: { messageId: bigint | number } };
+				}) {
+					requests.push(request.endMessageId.messageId);
+					if (requests.length === 1) {
+						return [
+							{
+								id: "9007199254740993", // 2^53 + 1
+								deliveredTime: 100,
+								contentType: "NONE",
+								contentMetadata: {},
+								text: "hi",
+							},
+						];
+					}
+					return [];
+				},
+			},
+		},
+	} as never as Client;
+
+	const chat = { mid: "c-chat" } as never;
+	const fetcher = await createMessageFetcher(client, chat);
+
+	const page1 = await fetcher.fetch(10);
+	assertEquals(page1.length, 1);
+
+	const page2 = await fetcher.fetch(10);
+	assertEquals(page2.length, 0);
+
+	assertEquals(requests[0], 9007199254740993n);
+	assertEquals(requests[1], 9007199254740993n);
+});

--- a/packages/linejs/client/features/chat/fetcher.ts
+++ b/packages/linejs/client/features/chat/fetcher.ts
@@ -25,10 +25,15 @@ export const createMessageFetcher = async (client: Client, chat: Chat) => {
 					messagesCount: limit,
 				},
 			});
+			if (!messages.length) {
+				return [];
+			}
 			const lastMessage = messages.at(-1)!;
+			// Message ids are 64-bit values far beyond Number.MAX_SAFE_INTEGER;
+			// parseInt silently rounds them and corrupts the pagination cursor.
 			lastMessageId = {
 				deliveredTime: lastMessage.deliveredTime,
-				messageId: parseInt(lastMessage.id),
+				messageId: BigInt(lastMessage.id),
 			};
 
 			return await Promise.all(

--- a/packages/linejs/client/features/message/square.test.ts
+++ b/packages/linejs/client/features/message/square.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { SquareMessage } from "./square.ts";
+import type { Client } from "../../client.ts";
+
+// `isMyMessage` is an async *method*, but `unsend()` tested it as a property
+// — a function object is always truthy, so the ownership guard never fired.
+Deno.test("unsend rejects messages that are not mine", async () => {
+	const client = {
+		base: {
+			profile: { mid: "u-self" },
+			square: {
+				async getSquareChat() {
+					return { squareChatMember: { squareMemberMid: "u-owner" } };
+				},
+				unsendMessage() {
+					throw new Error("must not be called");
+				},
+			},
+		},
+	} as never as Client;
+	const msg = new SquareMessage({
+		client,
+		raw: {
+			message: {
+				id: "sq-1",
+				to: "sq-chat",
+				from: "u-other",
+				toType: "SQUARE",
+				contentType: "NONE",
+				contentMetadata: {},
+				text: "hi",
+				createdTime: 0,
+			},
+			fromType: "USER",
+		} as never,
+	});
+
+	await assertRejects(
+		() => msg.unsend(),
+		TypeError,
+		"Cannot unsend the message which is not yours.",
+	);
+});

--- a/packages/linejs/client/features/message/square.ts
+++ b/packages/linejs/client/features/message/square.ts
@@ -142,7 +142,7 @@ export class SquareMessage {
 	 * Unsends the message.
 	 */
 	async unsend(): Promise<void> {
-		if (!this.isMyMessage) {
+		if (!(await this.isMyMessage())) {
 			throw new TypeError(
 				"Cannot unsend the message which is not yours.",
 			);
@@ -451,7 +451,7 @@ export class SquareThreadMessage extends SquareMessage {
 	#authorIsMe?: boolean;
 
 	constructor(init: SquareThreadMessageInit) {
-		super(init)
+		super(init);
 		this.#client = init.client;
 		this.raw = init.raw;
 	}
@@ -588,7 +588,7 @@ export class SquareThreadMessage extends SquareMessage {
 	 * Unsends the message.
 	 */
 	override async unsend() {
-		if (!this.isMyMessage) {
+		if (!(await this.isMyMessage())) {
 			throw new TypeError(
 				"Cannot unsend the message which is not yours.",
 			);
@@ -611,7 +611,10 @@ export class SquareThreadMessage extends SquareMessage {
 		});
 	}
 
-	static override fromSource(source: SquareEvent, client: Client): SquareThreadMessage {
+	static override fromSource(
+		source: SquareEvent,
+		client: Client,
+	): SquareThreadMessage {
 		return new SquareThreadMessage({
 			client,
 			raw: source.payload.notificationThreadMessage.squareMessage,

--- a/packages/linejs/client/features/message/talk.test.ts
+++ b/packages/linejs/client/features/message/talk.test.ts
@@ -4,10 +4,7 @@ import type { Client } from "../../client.ts";
 import { TalkMessage } from "./talk.ts";
 
 function message(raw: Partial<Message>): TalkMessage {
-	return new TalkMessage({
-		client: {} as Client,
-		raw: raw as Message,
-	});
+	return new TalkMessage({ client: {} as Client, raw: raw as Message });
 }
 
 Deno.test("TalkMessage.isEdited — never edited", () => {
@@ -20,9 +17,6 @@ Deno.test("TalkMessage.isEdited — never edited", () => {
 	);
 });
 
-// EDIT_MESSAGE / NOTIFIED_EDIT_MESSAGE operations mark the edit in
-// contentMetadata, not in the `updatedTime` field. Shape taken from a live
-// op 158 payload.
 Deno.test("TalkMessage.isEdited — edit operation metadata", () => {
 	const m = message({
 		id: "1234567890123456789",
@@ -54,7 +48,6 @@ Deno.test("TalkMessage.updatedTime", () => {
 		message({ text: "hi", updatedTime: 1700000000000 }).updatedTime,
 		1700000000000,
 	);
-	// metadata wins over the field
 	assertEquals(
 		message({
 			updatedTime: 1700000000000,
@@ -62,4 +55,63 @@ Deno.test("TalkMessage.updatedTime", () => {
 		}).updatedTime,
 		1787927539000,
 	);
+});
+
+function makeClient() {
+	const chatCheckedCalls: unknown[] = [];
+	const client = {
+		base: {
+			profile: { mid: "u-self" },
+			getReqseq: () => Promise.resolve(1),
+			talk: {
+				sendChatChecked(opts: unknown) {
+					chatCheckedCalls.push(opts);
+					return Promise.resolve({});
+				},
+			},
+		},
+	} as never as Client;
+	return { client, chatCheckedCalls };
+}
+
+function makeRaw(
+	opts: { to: string; from: string; toType: string; id?: string },
+) {
+	return {
+		id: opts.id ?? "msg-1",
+		to: opts.to,
+		from: opts.from,
+		toType: opts.toType,
+		contentType: "NONE",
+		contentMetadata: {},
+		text: "hi",
+	} as never;
+}
+
+Deno.test("read marks the group chat itself as read for received group messages", async () => {
+	const { client, chatCheckedCalls } = makeClient();
+	const msg = new TalkMessage({
+		client,
+		raw: makeRaw({ to: "g-group", from: "u-them", toType: "GROUP" }),
+	});
+	await msg.read();
+	assertEquals(chatCheckedCalls[0], {
+		chatMid: "g-group",
+		lastMessageId: "msg-1",
+		seq: 1,
+	});
+});
+
+Deno.test("read keeps 1:1 behavior (counterpart mid) for received DMs", async () => {
+	const { client, chatCheckedCalls } = makeClient();
+	const msg = new TalkMessage({
+		client,
+		raw: makeRaw({ to: "u-self", from: "u-them", toType: "USER" }),
+	});
+	await msg.read();
+	assertEquals(chatCheckedCalls[0], {
+		chatMid: "u-them",
+		lastMessageId: "msg-1",
+		seq: 1,
+	});
 });

--- a/packages/linejs/client/features/message/talk.ts
+++ b/packages/linejs/client/features/message/talk.ts
@@ -114,8 +114,15 @@ export class TalkMessage {
 	 * Read the message.
 	 */
 	async read(): Promise<void> {
+		// `chatMid` must be the chat id. In group/room chats `from` is the
+		// sender's USER mid, not the chat, so mark the chat itself read.
+		const chatMid = this.to.type === "GROUP" || this.to.type === "ROOM"
+			? this.to.id
+			: this.isMyMessage
+			? this.to.id
+			: this.from.id;
 		await this.#client.base.talk.sendChatChecked({
-			chatMid: this.isMyMessage ? this.to.id : this.from.id,
+			chatMid,
 			lastMessageId: this.raw.id,
 			seq: await this.#client.base.getReqseq(),
 		});

--- a/packages/types/line_types.ts
+++ b/packages/types/line_types.ts
@@ -12697,7 +12697,7 @@ export interface Pb1_C13070l5 {
 export interface Pb1_C13097n4 {
 	version: number;
 	keyId: number;
-	keyData: string;
+	keyData: string | Buffer;
 	createdTime: Int64;
 }
 


### PR DESCRIPTION
## Summary

- register E2EE public keys as raw 32-byte Thrift binary data
- preserve 64-bit message IDs when paginating chat history
- mark the correct group or room chat as read
- await Square message ownership checks before unsending
- add regression coverage for all fixes

## Verification

- deno test -A — 240 passed
- deno publish --dry-run — success

Fixes #216.
Supersedes #222.